### PR TITLE
fix: update persistent mode stream-json input format for claude-code v2.1+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Persistent mode stream-json input format updated for claude-code v2.1+**: The `stdinMessage` format now uses `{"type":"user","message":{"role":"user","content":"..."}}` instead of the deprecated `{"type":"user","text":"..."}` format, fixing immediate subprocess crashes on every prompt in persistent mode.
 - **Persistent mode subprocess lifetime is now decoupled from request contexts**: `PersistentProcess` reader/watchdog now use an internal lifecycle context so cancelling a single MCP request does not terminate persistent stream handling.
 - **`/readyz` now reflects Claude process health**: readiness returns `503` when the process is `starting`, `stopped`, or `error`, and `200` otherwise.
 - **Negative `CLAUDE_MAX_BUDGET_USD` and `CLAUDE_MAX_TURNS` now fail fast** with clear startup errors instead of being silently ignored.

--- a/pkg/claude/persistent_test.go
+++ b/pkg/claude/persistent_test.go
@@ -163,13 +163,19 @@ func TestPersistentProcess_PersistentArgs_Minimal(t *testing.T) {
 }
 
 func TestStdinMessage_JSON(t *testing.T) {
-	msg := stdinMessage{Type: "user", Text: "hello world"}
+	msg := stdinMessage{
+		Type: "user",
+		Message: stdinMessageContent{
+			Role:    "user",
+			Content: "hello world",
+		},
+	}
 	data, err := json.Marshal(msg)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	expected := `{"type":"user","text":"hello world"}`
+	expected := `{"type":"user","message":{"role":"user","content":"hello world"}}`
 	if string(data) != expected {
 		t.Errorf("expected %q, got %q", expected, string(data))
 	}


### PR DESCRIPTION
## Summary

- Fix persistent mode (`CLAUDE_PERSISTENT_MODE=true`) which is completely broken with claude-code v2.1+. The `stdinMessage` format sent to the subprocess stdin used `{"type":"user","text":"..."}` but claude-code v2.1+ now expects `{"type":"user","message":{"role":"user","content":"..."}}`, causing every prompt to crash the subprocess immediately.
- Update `stdinMessageContent` struct and `stdinMessage` struct in `pkg/claude/persistent.go` to use the new nested message format with `role` and `content` fields.
- Update corresponding test to verify the new serialization format.

Closes #20

## Test plan

- [x] `TestStdinMessage_JSON` verifies the new JSON serialization format
- [x] All existing persistent mode tests pass (`go test ./pkg/claude/ -v`)
- [x] Full test suite passes (`go test ./...`)
- [x] Verified new format accepted by claude-code v2.1.39 CLI
- [x] Verified old format still produces the reported error

Made with [Cursor](https://cursor.com)