### PR TITLE
feat: make prompt MCP tool non-blocking by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **`prompt` MCP tool is now non-blocking by default**: The `prompt` tool returns immediately with `{status: "started", session_id: "..."}` and runs the task in the background. Use the `status` tool to poll for progress and retrieve the result. Set `blocking=true` for the previous behavior of waiting for completion. This is a breaking change for callers that assume blocking behavior.
-- **`status` MCP tool now includes result on completion**: When idle after a completed run, the status response includes a `result` field with the agent's final output text, making it the primary way to retrieve results from non-blocking prompts.
+- **`status` MCP tool now includes result on completion**: When a non-blocking run completes, the status transitions to `completed` with a `result` field containing the agent's final output text. The `completed` status distinguishes "task finished with results" from `idle` ("never ran / no results").
+- **Non-blocking drain goroutines now use a server-scoped context**: Previously, drain goroutines used `context.Background()` and could be orphaned during server shutdown. They now use a server-scoped context that is cancelled during graceful shutdown, ensuring clean goroutine cleanup.
 
 ### Added
 
+- **`completed` process status**: New status that indicates a non-blocking Submit run has finished and results are available. Callers can now distinguish "task finished" (`completed`) from "never ran" (`idle`), making polling loops unambiguous.
 - **`result` MCP debug tool**: New tool that returns the full untruncated result text and detailed metadata (message history, costs, session info) from the last completed run. Intended for debugging and troubleshooting when the agent produces unexpected output.
 - `Submit()` method on `Prompter` interface for non-blocking prompt execution with background result collection.
 - `ResultDetail()` method on `Prompter` interface for retrieving full debug output from the last completed run.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Klaus runs the Claude Code CLI as a managed subprocess and exposes it over HTTP 
 | Tool | Description |
 |------|-------------|
 | `prompt` | Send a task to the Claude agent. Non-blocking by default (set `blocking=true` to wait for completion). |
-| `status` | Query agent state, progress, and result. Primary way to poll for results from non-blocking prompts. |
+| `status` | Query agent state, progress, and result. Returns `completed` with result when a non-blocking task finishes. |
 | `stop` | Terminate the running agent |
 | `result` | Get full untruncated result and message history from the last run (debugging tool) |
 
@@ -27,13 +27,15 @@ By default, `prompt` returns immediately and the task runs in the background:
    -> {status: "busy", message_count: 12, tool_call_count: 5, last_tool_name: "Edit", ...}
 
 3. status()                          # when complete
-   -> {status: "idle", result: "I've refactored...", total_cost_usd: 0.45, session_id: "..."}
+   -> {status: "completed", result: "I've refactored...", total_cost_usd: 0.45, session_id: "..."}
 
 4. result()                          # optional: full debug output
    -> {result_text: "...", messages: [...], message_count: 42, ...}
 ```
 
 For short queries, use `prompt(message: "...", blocking: true)` to get the result inline.
+
+**Status lifecycle:** `idle` (never ran) -> `busy` (task running) -> `completed` (result available). The result and `completed` status persist until the next `prompt` call clears them. There is no explicit "consumed" acknowledgement, so callers that poll should track whether they have already processed a given result.
 
 ### HTTP Endpoints
 

--- a/pkg/claude/message_test.go
+++ b/pkg/claude/message_test.go
@@ -110,6 +110,7 @@ func TestProcessStatus_Values(t *testing.T) {
 		ProcessStatusStarting,
 		ProcessStatusIdle,
 		ProcessStatusBusy,
+		ProcessStatusCompleted,
 		ProcessStatusStopped,
 		ProcessStatusError,
 	}

--- a/pkg/claude/persistent_test.go
+++ b/pkg/claude/persistent_test.go
@@ -98,7 +98,7 @@ func TestPersistentProcess_StatusNoResultWhenBusy(t *testing.T) {
 	process := NewPersistentProcess(DefaultOptions())
 
 	process.mu.Lock()
-	process.result.text = "old result"
+	process.result = resultState{text: "old result", completed: true}
 	process.status = ProcessStatusBusy
 	process.mu.Unlock()
 
@@ -108,15 +108,28 @@ func TestPersistentProcess_StatusNoResultWhenBusy(t *testing.T) {
 	}
 }
 
-func TestPersistentProcess_StatusShowsResultWhenIdle(t *testing.T) {
+func TestPersistentProcess_StatusNoResultWhenIdle(t *testing.T) {
+	process := NewPersistentProcess(DefaultOptions())
+
+	// idle with no completed result should not show result.
+	status := process.Status()
+	if status.Result != "" {
+		t.Errorf("expected empty result when idle, got %q", status.Result)
+	}
+}
+
+func TestPersistentProcess_StatusShowsResultWhenCompleted(t *testing.T) {
 	process := NewPersistentProcess(DefaultOptions())
 
 	process.mu.Lock()
-	process.result.text = "completed result"
-	process.status = ProcessStatusIdle
+	process.result = resultState{text: "completed result", completed: true}
+	process.status = ProcessStatusCompleted
 	process.mu.Unlock()
 
 	status := process.Status()
+	if status.Status != ProcessStatusCompleted {
+		t.Errorf("expected status %q, got %q", ProcessStatusCompleted, status.Status)
+	}
 	if status.Result != "completed result" {
 		t.Errorf("expected result %q, got %q", "completed result", status.Result)
 	}
@@ -131,8 +144,8 @@ func TestPersistentProcess_StatusTruncatesLongResult(t *testing.T) {
 		long[i] = 'x'
 	}
 	process.mu.Lock()
-	process.result.text = string(long)
-	process.status = ProcessStatusIdle
+	process.result = resultState{text: string(long), completed: true}
+	process.status = ProcessStatusCompleted
 	process.mu.Unlock()
 
 	status := process.Status()

--- a/pkg/claude/prompter.go
+++ b/pkg/claude/prompter.go
@@ -22,11 +22,15 @@ type Prompter interface {
 	// background goroutine to drain the message channel and store results,
 	// then returns immediately. The ctx should be a server-scoped context
 	// (not an MCP request context) so the drain goroutine outlives the caller.
-	// Use Status() to check progress and retrieve the result when complete.
+	// When the drain completes, the status transitions to "completed" and the
+	// result is available via Status() and ResultDetail(). The result persists
+	// until the next Submit call clears it.
 	Submit(ctx context.Context, prompt string, opts *RunOptions) error
 
-	// Status returns the current status information. When idle after a
-	// completed Submit run, the Result field contains the agent's output.
+	// Status returns the current status information. When the status is
+	// "completed" (after a non-blocking Submit finishes), the Result field
+	// contains the agent's truncated output. Use ResultDetail() for the
+	// full untruncated text.
 	Status() StatusInfo
 
 	// Stop stops the current operation or subprocess.

--- a/pkg/mcp/tools_test.go
+++ b/pkg/mcp/tools_test.go
@@ -476,7 +476,7 @@ func TestStatusTool(t *testing.T) {
 func TestStatusTool_WithResult(t *testing.T) {
 	mock := &mockPrompter{
 		status: claudepkg.StatusInfo{
-			Status:    claudepkg.ProcessStatusIdle,
+			Status:    claudepkg.ProcessStatusCompleted,
 			SessionID: "sess-xyz",
 			Result:    "Task completed successfully",
 		},
@@ -779,7 +779,7 @@ func TestOptionalFloat(t *testing.T) {
 func buildToolMap(process claudepkg.Prompter) map[string]func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	tools := map[string]func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error){}
 
-	pt := promptTool(process)
+	pt := promptTool(context.Background(), process)
 	tools[pt.Tool.Name] = pt.Handler
 
 	st := statusTool(process)

--- a/pkg/server/handlers_test.go
+++ b/pkg/server/handlers_test.go
@@ -91,6 +91,11 @@ func TestHandleReadyz(t *testing.T) {
 			wantStatus: http.StatusOK,
 		},
 		{
+			name:       "ready when completed",
+			status:     claude.ProcessStatusCompleted,
+			wantStatus: http.StatusOK,
+		},
+		{
 			name:       "not ready when starting",
 			status:     claude.ProcessStatusStarting,
 			wantStatus: http.StatusServiceUnavailable,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -24,8 +24,11 @@ const (
 	ModePersistent = "persistent"
 )
 
-func NewWithMode(process claudepkg.Prompter, port string, mode string) *Server {
-	mcpSrv := mcppkg.NewServer(process)
+// NewWithMode creates a Server that serves MCP and operational endpoints.
+// The serverCtx controls the lifetime of background goroutines; it should
+// be cancelled during server shutdown to ensure drain goroutines are cleaned up.
+func NewWithMode(serverCtx context.Context, process claudepkg.Prompter, port string, mode string) *Server {
+	mcpSrv := mcppkg.NewServer(serverCtx, process)
 
 	mux := http.NewServeMux()
 


### PR DESCRIPTION
## Summary

Closes #23

- **`prompt` tool is now non-blocking by default**: Returns immediately with `{status: "started", session_id: "..."}` and runs the task in the background. Set `blocking=true` for the previous synchronous behavior. This is a breaking change for callers that assume blocking behavior.
- **Explicit `completed` status**: New status that indicates a non-blocking Submit run has finished and results are available. Callers can now distinguish "task finished" (`completed`) from "never ran" (`idle`), making polling loops unambiguous.
- **`status` tool enhanced**: When status is `completed`, includes a `result` field with the agent's final output text (truncated to 4000 chars; use the `result` tool for the full text) -- the primary way to retrieve results from non-blocking prompts.
- **New `result` debug tool**: Returns the full untruncated result text and detailed metadata (message history, costs, session info) from the last completed run, intended for troubleshooting.
- **Server-scoped context for drain goroutines**: Non-blocking drain goroutines now use a server-scoped context that is cancelled during graceful shutdown, preventing goroutine leaks on server exit.

### Status lifecycle

```
idle (never ran) -> busy (task running) -> completed (result available)
```

The result and `completed` status persist until the next `prompt` call clears them. There is no explicit "consumed" acknowledgement; callers should track whether they have already processed a given result.

### Implementation details

- Shared `submitAsync()` helper and `resultState` struct eliminate duplicated Submit/result logic across `Process` and `PersistentProcess`
- `submitAsync()` calls `RunWithOptions`, spawns a background goroutine (`submitDrain`) to drain the message channel and store results, then returns immediately
- Previous results are preserved if `Submit()` fails (e.g. process already busy) -- result clearing happens only after the run starts successfully
- The drain goroutine uses a server-scoped context (threaded from `cmd/serve` through `RegisterTools`) so it outlives the MCP request context but is cancelled on shutdown
- `StatusInfo.Result` is truncated to 4000 runes to keep polling responses bounded; `ResultDetail()` returns the full untruncated text
- All four mode combinations work: single-shot/persistent x blocking/async
- One-prompt-at-a-time constraint preserved -- `Submit()` while busy returns "already busy"

### Workflow for MCP clients

```
1. prompt(message: "Refactor the auth module")
   -> {status: "started", session_id: "..."}

2. status()  (poll periodically)
   -> {status: "busy", message_count: 12, tool_call_count: 5, ...}

3. status()  (when completed)
   -> {status: "completed", result: "I've refactored...", total_cost_usd: 0.45}

4. result()  (optional, for debugging)
   -> {result_text: "...", messages: [...], message_count: 42, ...}
```

## Test plan

- [x] All existing tests updated for new default (non-blocking) behavior
- [x] New tests for non-blocking prompt (default, explicit, with run options, error)
- [x] New tests for blocking prompt (basic, with run options, error)
- [x] New tests for result tool (with data, empty)
- [x] New tests for status tool with result field (using `completed` status)
- [x] New tests for submitDrain helper (drain, context cancellation, empty channel)
- [x] New tests for submitAsync helper (preserves results on failure, clears and stores on success)
- [x] New tests for status result truncation (both Process and PersistentProcess)
- [x] New tests for Process/PersistentProcess ResultDetail and Status result behavior
- [x] New tests for `completed` status in readyz endpoint (returns 200)
- [x] New tests for idle status showing no result (distinguishes from completed)
- [x] Fixed flaky submitDrain context cancellation test (race in select with buffered channel)
- [x] `go test -race -count=5`, `go vet`, `goimports`, `go build` all pass