### PR TITLE
fix(helm): enable readOnlyRootFilesystem with emptyDir volumes

### DIFF
--- a/helm/klaus/templates/deployment.yaml
+++ b/helm/klaus/templates/deployment.yaml
@@ -273,6 +273,12 @@ spec:
             - name: workspace
               mountPath: /workspace
             {{- end }}
+            - name: tmp
+              mountPath: /tmp
+            - name: claude-home
+              mountPath: /home/klaus
+            - name: npm-cache
+              mountPath: /home/klaus/.npm
           livenessProbe:
             httpGet:
               path: /healthz
@@ -322,6 +328,12 @@ spec:
             claimName: {{ include "klaus.fullname" . }}-workspace
           {{- end }}
         {{- end }}
+        - name: tmp
+          emptyDir: {}
+        - name: claude-home
+          emptyDir: {}
+        - name: npm-cache
+          emptyDir: {}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/klaus/values.yaml
+++ b/helm/klaus/values.yaml
@@ -303,8 +303,7 @@ podSecurityContext:
 
 securityContext:
   allowPrivilegeEscalation: false
-  # Claude CLI needs to write to npm cache, git state, and workspace.
-  readOnlyRootFilesystem: false
+  readOnlyRootFilesystem: true
   capabilities:
     drop:
       - ALL


### PR DESCRIPTION
## Summary

- Set `readOnlyRootFilesystem: true` in the container security context
- Add `emptyDir` volumes for the specific paths Claude CLI needs to write to:
  - `/tmp` -- Node.js compile cache
  - `/home/klaus` -- Claude CLI state (`.claude/`, `.claude.json`)
  - `/home/klaus/.npm` -- npm cache and logs

## Why

The `push-to-app-catalog` CircleCI job fails because kube-linter flags the container for not having `readOnlyRootFilesystem: true`. Previously this was set to `false` with a comment about Claude CLI needing write access, but targeted `emptyDir` volumes are the more secure approach.

This was the remaining blocker after the icon fix (#44) -- both v0.0.13 and v0.0.14 failed to publish to the app catalog.

## Test plan

- [ ] CircleCI `push-to-app-catalog` job passes (kube-linter step)
- [ ] Deployed instance can still run prompts (Claude CLI writes to emptyDir mounts)
