### PR TITLE
fix: auto-allow MCP server tools and set SHELL env var in container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Auto-allow MCP server tools**: When an MCP config file is provided, `--allowedTools mcp__<server>__*` patterns are now auto-generated for each server, preventing Claude's permission system from blocking MCP tool calls even with `--permission-mode bypassPermissions`.
+- **Container missing `SHELL` environment variable**: Set `ENV SHELL=/bin/sh` in the Dockerfile so the Claude CLI Bash tool can find a valid shell. Without this, prompts requiring shell execution fail with "No suitable shell found".
 - **Persistent mode stream-json input format updated for claude-code v2.1+**: The `stdinMessage` format now uses `{"type":"user","message":{"role":"user","content":"..."}}` instead of the deprecated `{"type":"user","text":"..."}` format, fixing immediate subprocess crashes on every prompt in persistent mode.
 - **Persistent mode subprocess lifetime is now decoupled from request contexts**: `PersistentProcess` reader/watchdog now use an internal lifecycle context so cancelling a single MCP request does not terminate persistent stream handling.
 - **`/readyz` now reflects Claude process health**: readiness returns `503` when the process is `starting`, `stopped`, or `error`, and `200` otherwise.

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,7 @@ USER klaus
 WORKDIR /workspace
 
 ENV PORT=8080
+ENV SHELL=/bin/sh
 EXPOSE 8080
 
 ENTRYPOINT ["klaus"]

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -63,6 +63,7 @@ USER klaus
 WORKDIR /workspace
 
 ENV PORT=8080
+ENV SHELL=/bin/sh
 EXPOSE 8080
 
 ENTRYPOINT ["klaus"]


### PR DESCRIPTION
## Summary

- **Auto-allow MCP server tools**: When an MCP config file is provided via `CLAUDE_MCP_CONFIG`, the `baseArgs()` method now parses it to extract server names and auto-generates `--allowedTools mcp__<server>__*` patterns. This prevents Claude's permission system from blocking MCP tool calls even with `--permission-mode bypassPermissions`.
- **Set `SHELL` env var in container**: Added `ENV SHELL=/bin/sh` to both Alpine and Debian Dockerfiles. The Claude CLI Bash tool requires this env var to find a valid POSIX shell; without it, prompts requiring shell execution fail with "No suitable shell found".

## Test plan

- [x] Unit tests for `mcpServerNames()` covering: valid config with multiple servers, no config path, missing file, invalid JSON, empty servers map
- [x] All existing `pkg/claude` tests continue to pass
- [x] `go vet ./pkg/claude/` clean
- [ ] Manual verification: deploy a klaus instance with MCP servers configured and confirm tools are no longer blocked
- [ ] Manual verification: send a prompt requiring `ls` or similar shell command and confirm it executes successfully


Made with [Cursor](https://cursor.com)