### PR TITLE
fix: install bash in Alpine image for Claude CLI shell detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Auto-allow MCP server tools**: When an MCP config file is provided, `--allowedTools mcp__<server>__*` patterns are now auto-generated for each server, preventing Claude's permission system from blocking MCP tool calls even with `--permission-mode bypassPermissions`.
-- **Container missing `SHELL` environment variable**: Set `ENV SHELL=/bin/sh` in the Dockerfile so the Claude CLI Bash tool can find a valid shell. Without this, prompts requiring shell execution fail with "No suitable shell found".
+- **Container missing bash for Claude CLI shell detection**: Claude CLI requires `bash` or `zsh` in the shell path (not just any POSIX shell). Alpine now installs `bash` via `apk add` and both variants set `ENV SHELL=/bin/bash`.
 - **Persistent mode stream-json input format updated for claude-code v2.1+**: The `stdinMessage` format now uses `{"type":"user","message":{"role":"user","content":"..."}}` instead of the deprecated `{"type":"user","text":"..."}` format, fixing immediate subprocess crashes on every prompt in persistent mode.
 - **Persistent mode subprocess lifetime is now decoupled from request contexts**: `PersistentProcess` reader/watchdog now use an internal lifecycle context so cancelling a single MCP request does not terminate persistent stream handling.
 - **`/readyz` now reflects Claude process health**: readiness returns `503` when the process is `starting`, `stopped`, or `error`, and `200` otherwise.

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ ARG VARIANT
 
 # Install ca-certificates (required for TLS).
 RUN if [ "$VARIANT" = "alpine" ]; then \
-        apk add --no-cache ca-certificates; \
+        apk add --no-cache bash ca-certificates; \
     else \
         apt-get update && \
         apt-get install -y --no-install-recommends ca-certificates && \
@@ -59,7 +59,7 @@ USER klaus
 WORKDIR /workspace
 
 ENV PORT=8080
-ENV SHELL=/bin/sh
+ENV SHELL=/bin/bash
 EXPOSE 8080
 
 ENTRYPOINT ["klaus"]

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -33,7 +33,7 @@ ARG VARIANT
 
 # Install ca-certificates (required for TLS).
 RUN if [ "$VARIANT" = "alpine" ]; then \
-        apk add --no-cache ca-certificates; \
+        apk add --no-cache bash ca-certificates; \
     else \
         apt-get update && \
         apt-get install -y --no-install-recommends ca-certificates && \
@@ -63,7 +63,7 @@ USER klaus
 WORKDIR /workspace
 
 ENV PORT=8080
-ENV SHELL=/bin/sh
+ENV SHELL=/bin/bash
 EXPOSE 8080
 
 ENTRYPOINT ["klaus"]


### PR DESCRIPTION
## Summary

- **Install bash on Alpine**: Claude CLI's shell detection checks `q.includes("bash") || q.includes("zsh")`, rejecting busybox's `/bin/sh` regardless of the `SHELL` env var. Add `bash` to `apk add` in the Alpine Dockerfile.
- **Set `SHELL=/bin/bash`**: Update from `/bin/sh` to `/bin/bash` in both Alpine and Debian variants so the Claude CLI Bash tool finds a recognized shell.

Fixes the remaining "No suitable shell found" error from #67 when running on `klaus-go:0.0.3` (Alpine-based toolchain image).

## Test plan

- [ ] Build Alpine image and verify `docker run --rm klaus:alpine env | grep SHELL` outputs `/bin/bash`
- [ ] Build Alpine image and verify `docker run --rm klaus:alpine bash --version` succeeds
- [ ] Deploy a klaus instance and send a prompt requiring shell execution (e.g. `ls -l /`)


Made with [Cursor](https://cursor.com)