### PR TITLE
Switch to multiarch builds with OCI manifest annotations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  architect: giantswarm/architect@6.13.0
+  architect: giantswarm/architect@6.14.0
 
 workflows:
   build:
@@ -12,9 +12,14 @@ workflows:
           tags:
             only: /^v.*/
 
-    - architect/push-to-registries:
+    - architect/push-to-registries-multiarch:
         context: architect
         name: push-to-registries
+        resource_class: medium
+        annotations: |
+          manifest:io.giantswarm.klaus.type=toolchain
+          manifest:io.giantswarm.klaus.name=klaus
+          manifest:io.giantswarm.klaus.version=${DOCKER_IMAGE_TAG}
         requires:
         - go-build-klaus
         filters:
@@ -24,11 +29,16 @@ workflows:
             ignore:
             - main
 
-    - architect/push-to-registries:
+    - architect/push-to-registries-multiarch:
         context: architect
         name: push-to-registries-debian
         image: giantswarm/klaus-debian
         dockerfile: ./Dockerfile.debian
+        resource_class: medium
+        annotations: |
+          manifest:io.giantswarm.klaus.type=toolchain
+          manifest:io.giantswarm.klaus.name=klaus
+          manifest:io.giantswarm.klaus.version=${DOCKER_IMAGE_TAG}
         requires:
         - go-build-klaus
         filters:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,30 +70,3 @@ jobs:
         run: make release-dry-run-fast
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  docker-build:
-    name: Docker Build (${{ matrix.variant }})
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - variant: alpine
-            dockerfile: ./Dockerfile
-          - variant: debian
-            dockerfile: ./Dockerfile.debian
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build ${{ matrix.variant }} image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: ${{ matrix.dockerfile }}
-          push: false
-          tags: klaus:${{ matrix.variant }}
-          cache-from: type=gha,scope=docker-${{ matrix.variant }}
-          cache-to: type=gha,mode=max,scope=docker-${{ matrix.variant }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Switch CI builds from `push-to-registries` to `push-to-registries-multiarch`
+  (`architect-orb@6.14.0`) for multi-architecture support and OCI annotations.
+- Add OCI manifest annotations (`io.giantswarm.klaus.type=toolchain`, `.name`,
+  `.version`) and Docker labels on both Alpine and Debian images.
+
 ### Added
 
 - **OCI Artifacts documentation** (`docs/explanation/oci-artifacts.md`): Explains the OCI artifact format for plugins, personalities, and toolchains, the shared `klaus-oci` types library, and how each component (klausctl, Helm chart, klaus-operator) produces and consumes artifacts.

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -1,5 +1,5 @@
 # DO NOT EDIT. Generated from Dockerfile.
-# This file exists because the CircleCI architect orb does not support --build-arg.
+# This file exists so the CI job can build the Debian variant without --build-arg.
 # Regenerate with: make generate-dockerfile-debian
 
 # VARIANT controls the base distribution: "alpine" (default, ~50 MB) or "slim" (Debian, ~200 MB).
@@ -7,8 +7,8 @@
 # Declared before the first FROM so it is available to all FROM instructions.
 ARG VARIANT=slim
 
-# Stage 1: Build the Go binary.
-FROM golang:1.26.0 AS builder
+# Stage 1: Build the Go binary (runs on the build host, cross-compiles for target).
+FROM --platform=$BUILDPLATFORM golang:1.26.0 AS builder
 
 WORKDIR /app
 COPY go.mod go.sum ./
@@ -18,8 +18,8 @@ COPY . .
 ARG VERSION=dev
 ARG COMMIT=unknown
 ARG DATE=unknown
-ARG TARGETOS=linux
-ARG TARGETARCH=amd64
+ARG TARGETOS
+ARG TARGETARCH
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -trimpath \
     -ldflags "-w -extldflags '-static' \
     -X 'main.version=${VERSION}' \
@@ -59,6 +59,8 @@ RUN mkdir -p /workspace && chown klaus:klaus /workspace
 # Copy the Go binary from the builder stage.
 COPY --from=builder /app/klaus /usr/local/bin/klaus
 
+LABEL io.giantswarm.klaus.type=toolchain \
+      io.giantswarm.klaus.name=klaus
 USER klaus
 WORKDIR /workspace
 

--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -27,7 +27,7 @@ docker-build-debian: ## Build Debian Docker image
 	@docker build -f Dockerfile.debian -t klaus:debian .
 
 generate-dockerfile-debian: ## Regenerate Dockerfile.debian from Dockerfile (only VARIANT default differs)
-	@printf '# DO NOT EDIT. Generated from Dockerfile.\n# This file exists because the CircleCI architect orb does not support --build-arg.\n# Regenerate with: make generate-dockerfile-debian\n\n' > Dockerfile.debian
+	@printf '# DO NOT EDIT. Generated from Dockerfile.\n# This file exists so the CI job can build the Debian variant without --build-arg.\n# Regenerate with: make generate-dockerfile-debian\n\n' > Dockerfile.debian
 	@sed 's/^ARG VARIANT=alpine$$/ARG VARIANT=slim/' Dockerfile >> Dockerfile.debian
 
 ##@ Development


### PR DESCRIPTION
## Summary

- Bump `architect-orb` from `6.13.0` to `6.14.0` and switch both image push
  jobs from `push-to-registries` to `push-to-registries-multiarch` for
  linux/amd64 + linux/arm64 support.
- Add OCI manifest annotations (`io.giantswarm.klaus.type=toolchain`,
  `.name=klaus`, `.version`) to both Alpine and Debian images for remote
  discovery by `klausctl`.
- Add Docker `LABEL` instructions for local filtering with
  `docker images --filter label=io.giantswarm.klaus.type=toolchain`.

## Context

The downstream `klaus-images` repo needs the base `klaus` image to be published
as a multiarch manifest so that its own `push-to-registries-multiarch` builds
can pull the correct platform variant during cross-architecture builds.

## Related

- giantswarm/klaus-images#15 -- OCI annotations on toolchain images (blocked on this)