### PR TITLE
ci: publish base images to klaus-toolchains namespace

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,42 @@ workflows:
             ignore:
             - main
 
+    # Branch builds: publish to klaus-toolchains namespace
+    - architect/push-to-registries-multiarch:
+        context: architect
+        name: push-to-toolchains
+        image: giantswarm/klaus-toolchains/base
+        platforms: "linux/amd64"
+        resource_class: medium
+        annotations: |
+          manifest:io.giantswarm.klaus.type=toolchain
+          manifest:io.giantswarm.klaus.name=klaus
+          manifest:io.giantswarm.klaus.version=${DOCKER_IMAGE_TAG}
+        requires:
+        - go-build-klaus
+        filters:
+          branches:
+            ignore:
+            - main
+
+    - architect/push-to-registries-multiarch:
+        context: architect
+        name: push-to-toolchains-debian
+        image: giantswarm/klaus-toolchains/base-debian
+        dockerfile: ./Dockerfile.debian
+        platforms: "linux/amd64"
+        resource_class: medium
+        annotations: |
+          manifest:io.giantswarm.klaus.type=toolchain
+          manifest:io.giantswarm.klaus.name=klaus
+          manifest:io.giantswarm.klaus.version=${DOCKER_IMAGE_TAG}
+        requires:
+        - go-build-klaus
+        filters:
+          branches:
+            ignore:
+            - main
+
     # Tag builds: full multi-arch (amd64 + arm64)
     - architect/push-to-registries-multiarch:
         context: architect
@@ -63,6 +99,32 @@ workflows:
         context: architect
         name: push-to-registries-debian-release
         image: giantswarm/klaus-debian
+        dockerfile: ./Dockerfile.debian
+        requires:
+        - go-build-klaus
+        filters:
+          tags:
+            only: /^v.*/
+          branches:
+            ignore: /.*/
+
+    # Tag builds: publish to klaus-toolchains namespace
+    - architect/push-to-registries-multiarch:
+        context: architect
+        name: push-to-toolchains-release
+        image: giantswarm/klaus-toolchains/base
+        requires:
+        - go-build-klaus
+        filters:
+          tags:
+            only: /^v.*/
+          branches:
+            ignore: /.*/
+
+    - architect/push-to-registries-multiarch:
+        context: architect
+        name: push-to-toolchains-debian-release
+        image: giantswarm/klaus-toolchains/base-debian
         dockerfile: ./Dockerfile.debian
         requires:
         - go-build-klaus
@@ -114,6 +176,8 @@ workflows:
         - execute chart tests
         - push-to-registries
         - push-to-registries-debian
+        - push-to-toolchains
+        - push-to-toolchains-debian
         filters:
           branches:
             ignore:
@@ -131,6 +195,8 @@ workflows:
         - execute chart tests
         - push-to-registries-release
         - push-to-registries-debian-release
+        - push-to-toolchains-release
+        - push-to-toolchains-debian-release
         filters:
           tags:
             only: /^v.*/


### PR DESCRIPTION
## Summary

- Adds CircleCI workflows to publish the base klaus images additionally under the `klaus-toolchains` namespace as `giantswarm/klaus-toolchains/base` and `giantswarm/klaus-toolchains/base-debian`
- Existing `giantswarm/klaus` and `giantswarm/klaus-debian` publications remain unchanged to avoid surprises
- Chart push jobs now also depend on the new toolchain namespace image pushes

## Test plan

- [ ] Verify branch CI builds push `klaus-toolchains/base` and `klaus-toolchains/base-debian` (amd64)
- [ ] Verify tag release builds push multi-arch images to the toolchains namespace
- [ ] Confirm existing `giantswarm/klaus` and `giantswarm/klaus-debian` images are still published as before


Made with [Cursor](https://cursor.com)