### PR TITLE
ci: remove OCI manifest annotations from branch builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,10 +18,6 @@ workflows:
         name: push-to-registries
         platforms: "linux/amd64"
         resource_class: medium
-        annotations: |
-          manifest:io.giantswarm.klaus.type=toolchain
-          manifest:io.giantswarm.klaus.name=klaus
-          manifest:io.giantswarm.klaus.version=${DOCKER_IMAGE_TAG}
         requires:
         - go-build-klaus
         filters:
@@ -36,10 +32,6 @@ workflows:
         dockerfile: ./Dockerfile.debian
         platforms: "linux/amd64"
         resource_class: medium
-        annotations: |
-          manifest:io.giantswarm.klaus.type=toolchain
-          manifest:io.giantswarm.klaus.name=klaus
-          manifest:io.giantswarm.klaus.version=${DOCKER_IMAGE_TAG}
         requires:
         - go-build-klaus
         filters:
@@ -54,10 +46,6 @@ workflows:
         image: giantswarm/klaus-toolchains/base
         platforms: "linux/amd64"
         resource_class: medium
-        annotations: |
-          manifest:io.giantswarm.klaus.type=toolchain
-          manifest:io.giantswarm.klaus.name=klaus
-          manifest:io.giantswarm.klaus.version=${DOCKER_IMAGE_TAG}
         requires:
         - go-build-klaus
         filters:
@@ -72,10 +60,6 @@ workflows:
         dockerfile: ./Dockerfile.debian
         platforms: "linux/amd64"
         resource_class: medium
-        annotations: |
-          manifest:io.giantswarm.klaus.type=toolchain
-          manifest:io.giantswarm.klaus.name=klaus
-          manifest:io.giantswarm.klaus.version=${DOCKER_IMAGE_TAG}
         requires:
         - go-build-klaus
         filters:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Switch CI builds from `push-to-registries` to `push-to-registries-multiarch`
-  (`architect-orb@6.14.0`) for multi-architecture support and OCI annotations.
-- Add OCI manifest annotations (`io.giantswarm.klaus.type=toolchain`, `.name`,
-  `.version`) and Docker labels on both Alpine and Debian images.
+  (`architect-orb@6.14.0`) for multi-architecture support.
+- Remove OCI manifest annotations from CI builds (no longer needed).
+- Add Docker labels on both Alpine and Debian images.
 
 ### Added
 


### PR DESCRIPTION
## Summary

- Remove `annotations` blocks from all four branch-build `push-to-registries-multiarch` jobs (the OCI manifest annotations are no longer needed).
- Update CHANGELOG to reflect the removal.

This also triggers a new auto-release, which will fix the missing `base:0.0.31` toolchain tag -- the previous release push for `giantswarm/klaus-toolchains/base` failed silently, leaving only a branch-build tag (`0.0.30-<sha>`) in the registry.

## Test plan

- [ ] CI pipeline passes on the branch (all four image pushes succeed without annotations)
- [ ] After merge, verify auto-release creates a new tag
- [ ] After release, verify `klausctl toolchain list` shows a clean semver tag for `base`

Made with [Cursor](https://cursor.com)