### PR TITLE
fix(ci): restore goreleaser-action to v7

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -31,7 +31,7 @@ jobs:
           cache: true
 
       - name: Install GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
           version: latest
@@ -73,7 +73,7 @@ jobs:
           echo "Created and pushed tag $NEXT_VERSION"
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
           version: latest


### PR DESCRIPTION
Previous auto-release fix accidentally downgraded goreleaser-action from v7 to v6.

Made with [Cursor](https://cursor.com)