### PR TITLE
feat: read /etc/klaus/SOUL.md and append to system prompt

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -18,6 +19,18 @@ import (
 
 	"github.com/giantswarm/klaus/pkg/claude"
 	"github.com/giantswarm/klaus/pkg/server"
+)
+
+const (
+	// defaultSOULPath is the well-known location where klausctl mounts the
+	// personality SOUL.md file (read-only). If present, its content is appended
+	// to the system prompt so that personality identity definitions take effect.
+	defaultSOULPath = "/etc/klaus/SOUL.md"
+
+	// maxSOULFileSize is the maximum allowed size for a SOUL.md file (64 KiB).
+	// Personality files are short markdown documents; anything larger is likely
+	// a misconfiguration and could cause issues with CLI argument limits.
+	maxSOULFileSize = 64 * 1024
 )
 
 // newServeCmd creates the Cobra command for starting the klaus server.
@@ -304,6 +317,19 @@ func runServe(portFlag string, enableOAuth bool, oauthConfig server.OAuthConfig)
 		opts.NoSessionPersistence = parseBool(v)
 	}
 
+	// Load personality SOUL.md if mounted by klausctl.
+	// Content is appended after any CLAUDE_APPEND_SYSTEM_PROMPT value,
+	// separated by a blank line, so both the env var and file contribute.
+	if soul, err := loadSOULFile(defaultSOULPath); err != nil {
+		log.Printf("WARNING: failed to load personality from %s: %v", defaultSOULPath, err)
+	} else if soul != "" {
+		if opts.AppendSystemPrompt != "" {
+			opts.AppendSystemPrompt += "\n\n"
+		}
+		opts.AppendSystemPrompt += soul
+		log.Printf("Loaded personality from %s (%d bytes)", defaultSOULPath, len(soul))
+	}
+
 	// Validate configuration.
 	if err := claude.ValidatePermissionMode(opts.PermissionMode); err != nil {
 		return fmt.Errorf("configuration error: %w", err)
@@ -455,4 +481,29 @@ func parseBool(s string) bool {
 	default:
 		return false
 	}
+}
+
+// loadSOULFile reads a SOUL.md personality file and returns its content
+// with leading/trailing whitespace trimmed. Returns an empty string and
+// nil error when the file does not exist. Returns an error if the file
+// exceeds maxSOULFileSize.
+func loadSOULFile(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", nil
+		}
+		return "", err
+	}
+	defer f.Close()
+
+	limited := io.LimitReader(f, maxSOULFileSize+1)
+	data, err := io.ReadAll(limited)
+	if err != nil {
+		return "", err
+	}
+	if len(data) > maxSOULFileSize {
+		return "", fmt.Errorf("SOUL.md exceeds maximum size of %d bytes", maxSOULFileSize)
+	}
+	return strings.TrimSpace(string(data)), nil
 }

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -1,0 +1,180 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadSOULFile_Exists(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "SOUL.md")
+	content := "You are Klaus, a helpful AI assistant."
+
+	if err := os.WriteFile(path, []byte(content), 0o444); err != nil {
+		t.Fatalf("failed to write temp SOUL.md: %v", err)
+	}
+
+	got, err := loadSOULFile(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != content {
+		t.Errorf("expected %q, got %q", content, got)
+	}
+}
+
+func TestLoadSOULFile_NotExists(t *testing.T) {
+	got, err := loadSOULFile("/nonexistent/path/SOUL.md")
+	if err != nil {
+		t.Fatalf("expected nil error for missing file, got: %v", err)
+	}
+	if got != "" {
+		t.Errorf("expected empty string for missing file, got %q", got)
+	}
+}
+
+func TestLoadSOULFile_EmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "SOUL.md")
+
+	if err := os.WriteFile(path, []byte(""), 0o444); err != nil {
+		t.Fatalf("failed to write temp SOUL.md: %v", err)
+	}
+
+	got, err := loadSOULFile(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "" {
+		t.Errorf("expected empty string for empty file, got %q", got)
+	}
+}
+
+func TestLoadSOULFile_WhitespaceOnly(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "SOUL.md")
+
+	if err := os.WriteFile(path, []byte("  \n\n  \t  \n"), 0o444); err != nil {
+		t.Fatalf("failed to write temp SOUL.md: %v", err)
+	}
+
+	got, err := loadSOULFile(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "" {
+		t.Errorf("expected empty string for whitespace-only file, got %q", got)
+	}
+}
+
+func TestLoadSOULFile_TrimsWhitespace(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "SOUL.md")
+	content := "\n\n  You are a coding assistant.\n\n"
+
+	if err := os.WriteFile(path, []byte(content), 0o444); err != nil {
+		t.Fatalf("failed to write temp SOUL.md: %v", err)
+	}
+
+	got, err := loadSOULFile(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "You are a coding assistant."
+	if got != want {
+		t.Errorf("expected %q, got %q", want, got)
+	}
+}
+
+func TestLoadSOULFile_Unreadable(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "SOUL.md")
+
+	if err := os.WriteFile(path, []byte("secret"), 0o000); err != nil {
+		t.Fatalf("failed to write temp SOUL.md: %v", err)
+	}
+
+	// Skip if running as root (permissions not enforced).
+	if os.Getuid() == 0 {
+		t.Skip("skipping permission test as root")
+	}
+
+	_, err := loadSOULFile(path)
+	if err == nil {
+		t.Fatal("expected error for unreadable file, got nil")
+	}
+}
+
+func TestLoadSOULFile_MultilineContent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "SOUL.md")
+	content := "# Klaus Personality\n\nYou are Klaus.\nYou help with code.\n\n## Traits\n- Helpful\n- Concise"
+
+	if err := os.WriteFile(path, []byte(content), 0o444); err != nil {
+		t.Fatalf("failed to write temp SOUL.md: %v", err)
+	}
+
+	got, err := loadSOULFile(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != content {
+		t.Errorf("expected %q, got %q", content, got)
+	}
+}
+
+func TestLoadSOULFile_ExceedsMaxSize(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "SOUL.md")
+
+	// Create a file that is one byte over the limit.
+	data := strings.Repeat("A", maxSOULFileSize+1)
+	if err := os.WriteFile(path, []byte(data), 0o444); err != nil {
+		t.Fatalf("failed to write oversized SOUL.md: %v", err)
+	}
+
+	_, err := loadSOULFile(path)
+	if err == nil {
+		t.Fatal("expected error for oversized file, got nil")
+	}
+	if !strings.Contains(err.Error(), "exceeds maximum size") {
+		t.Errorf("expected size-related error, got: %v", err)
+	}
+}
+
+func TestLoadSOULFile_ExactlyMaxSize(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "SOUL.md")
+
+	// Create a file at exactly the limit -- should succeed.
+	data := strings.Repeat("B", maxSOULFileSize)
+	if err := os.WriteFile(path, []byte(data), 0o444); err != nil {
+		t.Fatalf("failed to write SOUL.md: %v", err)
+	}
+
+	got, err := loadSOULFile(path)
+	if err != nil {
+		t.Fatalf("unexpected error for max-size file: %v", err)
+	}
+	if got != data {
+		t.Errorf("expected %d bytes of content, got %d", len(data), len(got))
+	}
+}
+
+func TestParseBool(t *testing.T) {
+	trueCases := []string{"true", "TRUE", "True", "1", "yes", "YES", "Yes", " true ", " 1 "}
+	for _, tc := range trueCases {
+		if !parseBool(tc) {
+			t.Errorf("expected parseBool(%q) to be true", tc)
+		}
+	}
+
+	falseCases := []string{"false", "FALSE", "0", "no", "NO", "", "invalid", " false "}
+	for _, tc := range falseCases {
+		if parseBool(tc) {
+			t.Errorf("expected parseBool(%q) to be false", tc)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Read `/etc/klaus/SOUL.md` on startup and append its content to `AppendSystemPrompt`, so personality identity definitions mounted by klausctl actually take effect
- Content is appended after any `CLAUDE_APPEND_SYSTEM_PROMPT` env var value, separated by a blank line
- File-not-found is silently ignored (normal when no personality is mounted); other errors are logged as warnings
- Enforces a 64 KiB size limit to prevent resource exhaustion from oversized files
- Uses `errors.Is(err, os.ErrNotExist)` and `io.LimitReader` following Go best practices

## Test plan

- [x] `TestLoadSOULFile_Exists` -- reads a normal SOUL.md file
- [x] `TestLoadSOULFile_NotExists` -- missing file returns empty string, no error
- [x] `TestLoadSOULFile_EmptyFile` -- empty file returns empty string
- [x] `TestLoadSOULFile_WhitespaceOnly` -- whitespace-only file returns empty string
- [x] `TestLoadSOULFile_TrimsWhitespace` -- leading/trailing whitespace trimmed
- [x] `TestLoadSOULFile_Unreadable` -- permission error returns error
- [x] `TestLoadSOULFile_MultilineContent` -- multiline markdown preserved
- [x] `TestLoadSOULFile_ExceedsMaxSize` -- file over 64 KiB returns error
- [x] `TestLoadSOULFile_ExactlyMaxSize` -- file at exactly 64 KiB succeeds
- [x] `TestParseBool` -- existing helper test coverage
- [x] All existing tests pass (`go test ./...`)
- [x] `go vet ./...` clean

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)