### PR TITLE
Fix auto-release workflow YAML syntax error

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -16,7 +16,7 @@ jobs:
     name: Auto Release
     if: >-
       github.event.pull_request.merged &&
-      !startsWith(github.event.pull_request.title, \'Release v\')
+      !startsWith(github.event.pull_request.title, 'Release v')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Problem

The auto-release workflow has a YAML syntax error on line 19 -- backslash-escaped single quotes (`\'Release v\'`) in the `if` expression. GitHub Actions rejects this with:

> Unexpected symbol: `'Release`. Located at position 82 within expression

This has been broken since the escaping was introduced, preventing any new releases from being created when PRs merge. Notably, PR #88 (SOUL.md injection fix) merged on 2026-03-04 but was never released because of this.

**Failed run**: https://github.com/giantswarm/klaus/actions/runs/22663214895

## Fix

Remove the backslash escapes. In a YAML folded/literal block, single quotes don't need escaping.

## Acceptance criteria

- Auto-release workflow passes validation
- Next PR merge to main triggers a successful release (v0.0.38)

Made with [Cursor](https://cursor.com)