### PR TITLE
feat: notify downstream repos on release via repository_dispatch

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -88,7 +88,8 @@ jobs:
           RELEASE_VERSION: ${{ steps.version.outputs.next_version }}
         run: |
           if [ -z "$GH_TOKEN" ]; then
-            echo "::warning::DOWNSTREAM_DISPATCH_TOKEN is not set, skipping downstream notification"
+            echo "::warning::DOWNSTREAM_DISPATCH_TOKEN not set" \
+              "- skipping downstream notification"
             exit 0
           fi
 
@@ -98,7 +99,7 @@ jobs:
           )
           FAILED=0
           for repo in "${DOWNSTREAM_REPOS[@]}"; do
-            echo "Sending repository_dispatch to $repo (version: $RELEASE_VERSION)"
+            echo "Dispatching to $repo ($RELEASE_VERSION)"
             if gh api \
               --method POST \
               "/repos/${repo}/dispatches" \


### PR DESCRIPTION
## Summary

- Adds a "Notify downstream repos" step to the auto-release workflow that sends `repository_dispatch` events (event_type: `klaus-release`) with the version in `client_payload` to `klaus-toolchains` and `klaus-toolchains-internal` after a successful release
- Uses a dedicated `DOWNSTREAM_DISPATCH_TOKEN` secret for cross-repo API access
- Notification failures surface as GitHub Actions warnings but do not block the release (`continue-on-error: true`)

Closes #89

## Setup required

A `DOWNSTREAM_DISPATCH_TOKEN` repository secret must be configured with a PAT (or fine-grained token) that has `contents:write` permission on the downstream repos. If the secret is not set, the step logs a warning and exits cleanly.

## How it was tested

- Validated YAML syntax
- Reviewed against GitHub Actions expression injection best practices (version passed via `env:` block, not inline `${{ }}` interpolation)

## Self-review

**Code review (base:code-reviewer):**
- Fixed critical finding: moved `steps.version.outputs.next_version` from inline shell interpolation to `env:` block to prevent script injection
- Fixed warning: step now exits non-zero on dispatch failures (with `::warning::` annotations) so the step shows as failed in the UI, while `continue-on-error: true` keeps the overall job green
- Added guard for missing `DOWNSTREAM_DISPATCH_TOKEN` secret

**Security audit (code-quality:security-auditor):**
- Fixed high-severity script injection risk (finding #1) by using env var instead of inline expression
- Added token presence check to surface misconfiguration early (finding #3)
- Pre-existing injection patterns in other steps (e.g., `github.actor` on line 42) noted but out of scope for this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)