### PR TITLE
feat: add per-tool call breakdown to status and result endpoints

### DIFF
--- a/pkg/claude/message.go
+++ b/pkg/claude/message.go
@@ -92,14 +92,15 @@ var AllProcessStatuses = []ProcessStatus{
 const maxStatusResultLen = 4000
 
 type StatusInfo struct {
-	Status        ProcessStatus `json:"status"`
-	SessionID     string        `json:"session_id,omitempty"`
-	ErrorMessage  string        `json:"error,omitempty"`
-	TotalCost     float64       `json:"total_cost_usd,omitempty"`
-	MessageCount  int           `json:"message_count,omitempty"`
-	ToolCallCount int           `json:"tool_call_count,omitempty"`
-	LastMessage   string        `json:"last_message,omitempty"`
-	LastToolName  string        `json:"last_tool_name,omitempty"`
+	Status        ProcessStatus  `json:"status"`
+	SessionID     string         `json:"session_id,omitempty"`
+	ErrorMessage  string         `json:"error,omitempty"`
+	TotalCost     float64        `json:"total_cost_usd,omitempty"`
+	MessageCount  int            `json:"message_count,omitempty"`
+	ToolCallCount int            `json:"tool_call_count,omitempty"`
+	ToolCalls     map[string]int `json:"tool_calls,omitempty"`
+	LastMessage   string         `json:"last_message,omitempty"`
+	LastToolName  string         `json:"last_tool_name,omitempty"`
 	// Result contains the agent's final output text from the last completed
 	// non-blocking Submit run, truncated to maxStatusResultLen runes. It is
 	// populated when the status is "completed". Use the result debug tool
@@ -119,10 +120,24 @@ type ResultDetailInfo struct {
 	ResultText   string          `json:"result_text"`
 	Messages     []StreamMessage `json:"messages,omitempty"`
 	MessageCount int             `json:"message_count"`
+	ToolCalls    map[string]int  `json:"tool_calls,omitempty"`
 	TotalCost    float64         `json:"total_cost_usd,omitempty"`
 	SessionID    string          `json:"session_id,omitempty"`
 	Status       ProcessStatus   `json:"status"`
 	ErrorMessage string          `json:"error,omitempty"`
+}
+
+// copyToolCalls returns a shallow copy of the map to avoid exposing internal
+// state to callers. Returns nil for nil input.
+func copyToolCalls(m map[string]int) map[string]int {
+	if m == nil {
+		return nil
+	}
+	cp := make(map[string]int, len(m))
+	for k, v := range m {
+		cp[k] = v
+	}
+	return cp
 }
 
 // resultState holds the output of the last completed Submit run.

--- a/pkg/claude/message_test.go
+++ b/pkg/claude/message_test.go
@@ -223,6 +223,33 @@ func TestSubmitDrain(t *testing.T) {
 	})
 }
 
+func TestCopyToolCalls(t *testing.T) {
+	t.Run("nil returns nil", func(t *testing.T) {
+		if got := copyToolCalls(nil); got != nil {
+			t.Errorf("expected nil, got %v", got)
+		}
+	})
+
+	t.Run("empty map returns empty non-nil map", func(t *testing.T) {
+		cp := copyToolCalls(map[string]int{})
+		if cp == nil {
+			t.Error("expected non-nil copy of empty map")
+		}
+		if len(cp) != 0 {
+			t.Errorf("expected empty map, got %v", cp)
+		}
+	})
+
+	t.Run("returns independent copy", func(t *testing.T) {
+		original := map[string]int{"Bash": 3, "Read": 1}
+		cp := copyToolCalls(original)
+		cp["Bash"] = 999
+		if original["Bash"] != 3 {
+			t.Errorf("expected original unchanged, got Bash=%d", original["Bash"])
+		}
+	})
+}
+
 func TestSubmitAsync(t *testing.T) {
 	t.Run("preserves previous result on run failure", func(t *testing.T) {
 		// Simulate a previous result that should be preserved when the

--- a/pkg/claude/persistent.go
+++ b/pkg/claude/persistent.go
@@ -32,6 +32,7 @@ type PersistentProcess struct {
 	totalCost     float64
 	messageCount  int
 	toolCallCount int
+	toolCalls     map[string]int
 	lastMessage   string
 	lastToolName  string
 
@@ -273,6 +274,7 @@ func (p *PersistentProcess) readLoop(ctx context.Context, stdout io.ReadCloser, 
 			if msg.Subtype == SubtypeToolUse {
 				p.toolCallCount++
 				p.lastToolName = msg.ToolName
+				p.toolCalls[msg.ToolName]++
 			}
 		}
 		// Compute the cost delta before overwriting the running total so we
@@ -383,6 +385,7 @@ func (p *PersistentProcess) RunWithOptions(ctx context.Context, prompt string, r
 	p.lastError = ""
 	p.messageCount = 0
 	p.toolCallCount = 0
+	p.toolCalls = make(map[string]int)
 	p.lastMessage = ""
 	p.lastToolName = ""
 
@@ -526,6 +529,7 @@ func (p *PersistentProcess) Status() StatusInfo {
 		TotalCost:     p.totalCost,
 		MessageCount:  p.messageCount,
 		ToolCallCount: p.toolCallCount,
+		ToolCalls:     copyToolCalls(p.toolCalls),
 		LastMessage:   p.lastMessage,
 		LastToolName:  p.lastToolName,
 	}
@@ -547,6 +551,7 @@ func (p *PersistentProcess) ResultDetail() ResultDetailInfo {
 		ResultText:   p.result.text,
 		Messages:     p.result.messages,
 		MessageCount: len(p.result.messages),
+		ToolCalls:    copyToolCalls(p.toolCalls),
 		TotalCost:    p.totalCost,
 		SessionID:    p.sessionID,
 		Status:       p.status,

--- a/pkg/claude/persistent_test.go
+++ b/pkg/claude/persistent_test.go
@@ -24,6 +24,9 @@ func TestNewPersistentProcess_InitialState(t *testing.T) {
 	if status.ToolCallCount != 0 {
 		t.Errorf("expected 0 tool call count, got %d", status.ToolCallCount)
 	}
+	if status.ToolCalls != nil {
+		t.Errorf("expected nil tool calls, got %v", status.ToolCalls)
+	}
 	if status.LastMessage != "" {
 		t.Errorf("expected empty last message, got %q", status.LastMessage)
 	}
@@ -59,6 +62,68 @@ func TestPersistentProcess_MarshalStatus(t *testing.T) {
 
 	if info.Status != ProcessStatusIdle {
 		t.Errorf("expected status %q, got %q", ProcessStatusIdle, info.Status)
+	}
+}
+
+func TestPersistentProcess_StatusToolCalls(t *testing.T) {
+	process := NewPersistentProcess(DefaultOptions())
+
+	process.mu.Lock()
+	process.status = ProcessStatusBusy
+	process.toolCallCount = 4
+	process.toolCalls = map[string]int{
+		"Bash": 2,
+		"Read": 1,
+		"Glob": 1,
+	}
+	process.mu.Unlock()
+
+	status := process.Status()
+	if status.ToolCallCount != 4 {
+		t.Errorf("expected tool_call_count 4, got %d", status.ToolCallCount)
+	}
+	if len(status.ToolCalls) != 3 {
+		t.Fatalf("expected 3 tool entries, got %d", len(status.ToolCalls))
+	}
+	if status.ToolCalls["Bash"] != 2 {
+		t.Errorf("expected Bash count 2, got %d", status.ToolCalls["Bash"])
+	}
+	if status.ToolCalls["Read"] != 1 {
+		t.Errorf("expected Read count 1, got %d", status.ToolCalls["Read"])
+	}
+	if status.ToolCalls["Glob"] != 1 {
+		t.Errorf("expected Glob count 1, got %d", status.ToolCalls["Glob"])
+	}
+
+	// Verify the returned map is a copy.
+	status.ToolCalls["Bash"] = 999
+	status2 := process.Status()
+	if status2.ToolCalls["Bash"] != 2 {
+		t.Errorf("expected internal map to be unchanged, got Bash=%d", status2.ToolCalls["Bash"])
+	}
+}
+
+func TestPersistentProcess_ResultDetailToolCalls(t *testing.T) {
+	process := NewPersistentProcess(DefaultOptions())
+
+	process.mu.Lock()
+	process.status = ProcessStatusCompleted
+	process.result = resultState{text: "done", completed: true}
+	process.toolCalls = map[string]int{
+		"Bash": 5,
+		"Task": 1,
+	}
+	process.mu.Unlock()
+
+	detail := process.ResultDetail()
+	if len(detail.ToolCalls) != 2 {
+		t.Fatalf("expected 2 tool entries, got %d", len(detail.ToolCalls))
+	}
+	if detail.ToolCalls["Bash"] != 5 {
+		t.Errorf("expected Bash count 5, got %d", detail.ToolCalls["Bash"])
+	}
+	if detail.ToolCalls["Task"] != 1 {
+		t.Errorf("expected Task count 1, got %d", detail.ToolCalls["Task"])
 	}
 }
 

--- a/pkg/claude/process.go
+++ b/pkg/claude/process.go
@@ -82,6 +82,7 @@ type Process struct {
 	totalCost     float64
 	messageCount  int
 	toolCallCount int
+	toolCalls     map[string]int
 	lastMessage   string
 	lastToolName  string
 
@@ -155,6 +156,7 @@ func (p *Process) RunWithOptions(ctx context.Context, prompt string, runOpts *Ru
 	p.lastError = ""
 	p.messageCount = 0
 	p.toolCallCount = 0
+	p.toolCalls = make(map[string]int)
 	p.lastMessage = ""
 	p.lastToolName = ""
 
@@ -274,6 +276,7 @@ func (p *Process) RunWithOptions(ctx context.Context, prompt string, runOpts *Ru
 				if msg.Subtype == SubtypeToolUse {
 					p.toolCallCount++
 					p.lastToolName = msg.ToolName
+					p.toolCalls[msg.ToolName]++
 				}
 			}
 			if msg.Type == MessageTypeResult {
@@ -405,6 +408,7 @@ func (p *Process) Status() StatusInfo {
 		TotalCost:     p.totalCost,
 		MessageCount:  p.messageCount,
 		ToolCallCount: p.toolCallCount,
+		ToolCalls:     copyToolCalls(p.toolCalls),
 		LastMessage:   p.lastMessage,
 		LastToolName:  p.lastToolName,
 	}
@@ -426,6 +430,7 @@ func (p *Process) ResultDetail() ResultDetailInfo {
 		ResultText:   p.result.text,
 		Messages:     p.result.messages,
 		MessageCount: len(p.result.messages),
+		ToolCalls:    copyToolCalls(p.toolCalls),
 		TotalCost:    p.totalCost,
 		SessionID:    p.sessionID,
 		Status:       p.status,

--- a/pkg/claude/process_test.go
+++ b/pkg/claude/process_test.go
@@ -24,6 +24,9 @@ func TestNewProcess_InitialState(t *testing.T) {
 	if status.ToolCallCount != 0 {
 		t.Errorf("expected 0 tool call count, got %d", status.ToolCallCount)
 	}
+	if status.ToolCalls != nil {
+		t.Errorf("expected nil tool calls, got %v", status.ToolCalls)
+	}
 	if status.LastMessage != "" {
 		t.Errorf("expected empty last message, got %q", status.LastMessage)
 	}
@@ -154,6 +157,113 @@ func TestProcess_StatusTruncatesLongResult(t *testing.T) {
 	detail := process.ResultDetail()
 	if detail.ResultText != string(long) {
 		t.Error("expected ResultDetail to return full untruncated text")
+	}
+}
+
+func TestProcess_StatusToolCalls(t *testing.T) {
+	process := NewProcess(DefaultOptions())
+
+	// Simulate tool calls being recorded during a run.
+	process.mu.Lock()
+	process.status = ProcessStatusBusy
+	process.toolCallCount = 5
+	process.toolCalls = map[string]int{
+		"Bash": 3,
+		"Read": 2,
+	}
+	process.mu.Unlock()
+
+	status := process.Status()
+	if status.ToolCallCount != 5 {
+		t.Errorf("expected tool_call_count 5, got %d", status.ToolCallCount)
+	}
+	if len(status.ToolCalls) != 2 {
+		t.Fatalf("expected 2 tool entries, got %d", len(status.ToolCalls))
+	}
+	if status.ToolCalls["Bash"] != 3 {
+		t.Errorf("expected Bash count 3, got %d", status.ToolCalls["Bash"])
+	}
+	if status.ToolCalls["Read"] != 2 {
+		t.Errorf("expected Read count 2, got %d", status.ToolCalls["Read"])
+	}
+
+	// Verify the returned map is a copy (not a reference to internal state).
+	status.ToolCalls["Bash"] = 999
+	status2 := process.Status()
+	if status2.ToolCalls["Bash"] != 3 {
+		t.Errorf("expected internal map to be unchanged, got Bash=%d", status2.ToolCalls["Bash"])
+	}
+}
+
+func TestProcess_ResultDetailToolCalls(t *testing.T) {
+	process := NewProcess(DefaultOptions())
+
+	process.mu.Lock()
+	process.status = ProcessStatusCompleted
+	process.result = resultState{text: "done", completed: true}
+	process.toolCalls = map[string]int{
+		"Glob":      2,
+		"TodoWrite": 1,
+	}
+	process.mu.Unlock()
+
+	detail := process.ResultDetail()
+	if len(detail.ToolCalls) != 2 {
+		t.Fatalf("expected 2 tool entries, got %d", len(detail.ToolCalls))
+	}
+	if detail.ToolCalls["Glob"] != 2 {
+		t.Errorf("expected Glob count 2, got %d", detail.ToolCalls["Glob"])
+	}
+	if detail.ToolCalls["TodoWrite"] != 1 {
+		t.Errorf("expected TodoWrite count 1, got %d", detail.ToolCalls["TodoWrite"])
+	}
+}
+
+func TestProcess_ToolCallsInJSON(t *testing.T) {
+	process := NewProcess(DefaultOptions())
+
+	process.mu.Lock()
+	process.status = ProcessStatusBusy
+	process.toolCallCount = 3
+	process.toolCalls = map[string]int{
+		"Bash": 2,
+		"Read": 1,
+	}
+	process.mu.Unlock()
+
+	data, err := process.MarshalStatus()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var info StatusInfo
+	if err := json.Unmarshal(data, &info); err != nil {
+		t.Fatalf("failed to unmarshal status: %v", err)
+	}
+
+	if info.ToolCalls["Bash"] != 2 {
+		t.Errorf("expected Bash=2 in JSON, got %d", info.ToolCalls["Bash"])
+	}
+	if info.ToolCalls["Read"] != 1 {
+		t.Errorf("expected Read=1 in JSON, got %d", info.ToolCalls["Read"])
+	}
+}
+
+func TestProcess_ToolCallsOmittedWhenNil(t *testing.T) {
+	process := NewProcess(DefaultOptions())
+
+	data, err := process.MarshalStatus()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// tool_calls should be omitted from JSON when nil.
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	if _, exists := raw["tool_calls"]; exists {
+		t.Error("expected tool_calls to be omitted from JSON when nil")
 	}
 }
 

--- a/pkg/mcp/tools_test.go
+++ b/pkg/mcp/tools_test.go
@@ -437,6 +437,7 @@ func TestStatusTool(t *testing.T) {
 			SessionID:     "sess-xyz",
 			MessageCount:  5,
 			ToolCallCount: 2,
+			ToolCalls:     map[string]int{"Bash": 1, "Read": 1},
 			LastMessage:   "Working on it...",
 			LastToolName:  "Bash",
 		},
@@ -470,6 +471,12 @@ func TestStatusTool(t *testing.T) {
 	}
 	if info.ToolCallCount != 2 {
 		t.Errorf("expected tool_call_count 2, got %d", info.ToolCallCount)
+	}
+	if info.ToolCalls["Bash"] != 1 {
+		t.Errorf("expected tool_calls[Bash]=1, got %d", info.ToolCalls["Bash"])
+	}
+	if info.ToolCalls["Read"] != 1 {
+		t.Errorf("expected tool_calls[Read]=1, got %d", info.ToolCalls["Read"])
 	}
 }
 
@@ -511,6 +518,7 @@ func TestResultTool(t *testing.T) {
 		resultDetail: claudepkg.ResultDetailInfo{
 			ResultText:   "Full result text here",
 			MessageCount: 5,
+			ToolCalls:    map[string]int{"Bash": 3, "Read": 2},
 			TotalCost:    0.15,
 			SessionID:    "sess-123",
 			Status:       claudepkg.ProcessStatusIdle,
@@ -539,6 +547,12 @@ func TestResultTool(t *testing.T) {
 	}
 	if detail.MessageCount != 5 {
 		t.Errorf("expected message_count 5, got %d", detail.MessageCount)
+	}
+	if detail.ToolCalls["Bash"] != 3 {
+		t.Errorf("expected tool_calls[Bash]=3, got %d", detail.ToolCalls["Bash"])
+	}
+	if detail.ToolCalls["Read"] != 2 {
+		t.Errorf("expected tool_calls[Read]=2, got %d", detail.ToolCalls["Read"])
 	}
 	if detail.TotalCost != 0.15 {
 		t.Errorf("expected total_cost_usd 0.15, got %f", detail.TotalCost)


### PR DESCRIPTION
## Summary

- Adds a `tool_calls` map (`map[string]int`) to `StatusInfo` and `ResultDetailInfo` that provides per-tool counts alongside the existing aggregate `tool_call_count`
- Populated in the stream loop of both `Process` and `PersistentProcess`, reset on each new run
- Returns defensive copies via `copyToolCalls()` to prevent callers from mutating internal state
- Field uses `omitempty` JSON tag so it is omitted when no tools have been called

Example output:
```json
{
  "tool_call_count": 39,
  "tool_calls": {
    "Bash": 21,
    "Read": 14,
    "Glob": 2,
    "Task": 1,
    "TodoWrite": 1
  }
}
```

Closes #82

## Self-review

**Code review (base:code-reviewer):** No critical findings. Implementation follows existing locking discipline and conventions. Defensive copy correctly prevents callers from mutating internal state.

**Security audit (code-quality:security-auditor):** No critical/high/medium findings. One low-severity note about theoretical unbounded map growth from a compromised subprocess, accepted given the trusted data source.

## Test plan

- [x] Added `TestProcess_StatusToolCalls` -- verifies per-tool counts and defensive copy isolation
- [x] Added `TestProcess_ResultDetailToolCalls` -- verifies tool_calls in ResultDetail
- [x] Added `TestProcess_ToolCallsInJSON` -- verifies JSON serialization round-trip
- [x] Added `TestProcess_ToolCallsOmittedWhenNil` -- verifies omitempty behavior
- [x] Added `TestCopyToolCalls` -- unit tests for the copy helper (nil, empty, populated)
- [x] Added `TestPersistentProcess_StatusToolCalls` -- same coverage for persistent mode
- [x] Added `TestPersistentProcess_ResultDetailToolCalls` -- persistent mode ResultDetail
- [x] Updated `TestStatusTool` and `TestResultTool` in MCP tools to verify tool_calls in JSON responses
- [x] Updated initial state tests for both Process and PersistentProcess
- [x] All existing tests pass (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)