### PR TITLE
feat: persist session results to disk for retrieval after agent stop

### DIFF
--- a/pkg/claude/persistent.go
+++ b/pkg/claude/persistent.go
@@ -40,6 +40,10 @@ type PersistentProcess struct {
 	// allowing callers to retrieve results asynchronously.
 	result resultState
 
+	// resultStore persists results to disk so they survive restarts.
+	// Nil means no persistence.
+	resultStore *ResultStore
+
 	// responseCh receives stream-json messages during an active prompt.
 	// It is set by Send and cleared when the response is complete.
 	responseCh chan StreamMessage
@@ -76,6 +80,7 @@ func NewPersistentProcess(opts Options) *PersistentProcess {
 		done:        done,
 		processDone: processDone,
 		autoRestart: true,
+		resultStore: NewResultStore(ResultStorePath(opts.WorkDir)),
 	}
 }
 
@@ -513,15 +518,20 @@ func (p *PersistentProcess) Submit(ctx context.Context, prompt string, opts *Run
 		if rs.completed && p.status == ProcessStatusIdle {
 			p.status = ProcessStatusCompleted
 		}
+		status := p.status
+		sessionID := p.sessionID
+		totalCost := p.totalCost
+		lastError := p.lastError
+		store := p.resultStore
 		p.mu.Unlock()
+
+		persistResult(store, rs, status, sessionID, totalCost, lastError)
 	})
 }
 
 // Status returns the current status information.
 func (p *PersistentProcess) Status() StatusInfo {
 	p.mu.RLock()
-	defer p.mu.RUnlock()
-
 	info := StatusInfo{
 		Status:        p.status,
 		SessionID:     p.sessionID,
@@ -538,16 +548,35 @@ func (p *PersistentProcess) Status() StatusInfo {
 		info.Result = Truncate(p.result.text, maxStatusResultLen)
 	}
 
+	store := p.resultStore
+	p.mu.RUnlock()
+
+	// Fall back to disk when in-memory result is empty and a store exists.
+	// Skip disk I/O when the process is actively running to avoid unnecessary reads.
+	if info.Result == "" && store != nil && info.Status != ProcessStatusBusy && info.Status != ProcessStatusStarting {
+		if pr, err := store.Load(); err == nil && pr != nil && pr.ResultText != "" {
+			info.Result = Truncate(pr.ResultText, maxStatusResultLen)
+			if info.SessionID == "" {
+				info.SessionID = pr.SessionID
+			}
+			if info.TotalCost == 0 {
+				info.TotalCost = pr.TotalCost
+			}
+			if info.ErrorMessage == "" {
+				info.ErrorMessage = pr.ErrorMessage
+			}
+		}
+	}
+
 	return info
 }
 
 // ResultDetail returns the full untruncated result and detailed metadata from
-// the last completed Submit run. Intended for debugging and troubleshooting.
+// the last completed Submit run. Falls back to the persisted result on disk
+// when the in-memory state is empty.
 func (p *PersistentProcess) ResultDetail() ResultDetailInfo {
 	p.mu.RLock()
-	defer p.mu.RUnlock()
-
-	return ResultDetailInfo{
+	detail := ResultDetailInfo{
 		ResultText:   p.result.text,
 		Messages:     p.result.messages,
 		MessageCount: len(p.result.messages),
@@ -557,6 +586,17 @@ func (p *PersistentProcess) ResultDetail() ResultDetailInfo {
 		Status:       p.status,
 		ErrorMessage: p.lastError,
 	}
+	store := p.resultStore
+	p.mu.RUnlock()
+
+	// Fall back to disk when in-memory result is empty.
+	if detail.ResultText == "" && store != nil {
+		if pr, err := store.Load(); err == nil && pr != nil {
+			return pr.ToResultDetailInfo()
+		}
+	}
+
+	return detail
 }
 
 // Done returns a channel closed when the current prompt response is complete.

--- a/pkg/claude/process.go
+++ b/pkg/claude/process.go
@@ -90,6 +90,10 @@ type Process struct {
 	// allowing callers to retrieve results asynchronously.
 	result resultState
 
+	// resultStore persists results to disk so they survive restarts.
+	// Nil means no persistence.
+	resultStore *ResultStore
+
 	done      chan struct{}
 	runCancel context.CancelFunc // cancels the stdout-reading goroutine
 }
@@ -100,9 +104,10 @@ func NewProcess(opts Options) *Process {
 	done := make(chan struct{})
 	close(done) // Pre-closed: "not running" == "already done".
 	return &Process{
-		opts:   opts,
-		status: ProcessStatusIdle,
-		done:   done,
+		opts:        opts,
+		status:      ProcessStatusIdle,
+		done:        done,
+		resultStore: NewResultStore(ResultStorePath(opts.WorkDir)),
 	}
 }
 
@@ -393,14 +398,19 @@ func (p *Process) Submit(ctx context.Context, prompt string, opts *RunOptions) e
 		if rs.completed && p.status == ProcessStatusIdle {
 			p.status = ProcessStatusCompleted
 		}
+		status := p.status
+		sessionID := p.sessionID
+		totalCost := p.totalCost
+		lastError := p.lastError
+		store := p.resultStore
 		p.mu.Unlock()
+
+		persistResult(store, rs, status, sessionID, totalCost, lastError)
 	})
 }
 
 func (p *Process) Status() StatusInfo {
 	p.mu.RLock()
-	defer p.mu.RUnlock()
-
 	info := StatusInfo{
 		Status:        p.status,
 		SessionID:     p.sessionID,
@@ -417,16 +427,37 @@ func (p *Process) Status() StatusInfo {
 		info.Result = Truncate(p.result.text, maxStatusResultLen)
 	}
 
+	store := p.resultStore
+	p.mu.RUnlock()
+
+	// Fall back to disk when in-memory result is empty and a store exists.
+	// Skip disk I/O when the process is actively running to avoid unnecessary reads.
+	if info.Result == "" && store != nil && info.Status != ProcessStatusBusy && info.Status != ProcessStatusStarting {
+		if pr, err := store.Load(); err == nil && pr != nil && pr.ResultText != "" {
+			info.Result = Truncate(pr.ResultText, maxStatusResultLen)
+			// Backfill status metadata from persisted result if the
+			// in-memory state has been cleared (e.g. after restart).
+			if info.SessionID == "" {
+				info.SessionID = pr.SessionID
+			}
+			if info.TotalCost == 0 {
+				info.TotalCost = pr.TotalCost
+			}
+			if info.ErrorMessage == "" {
+				info.ErrorMessage = pr.ErrorMessage
+			}
+		}
+	}
+
 	return info
 }
 
 // ResultDetail returns the full untruncated result and detailed metadata from
 // the last completed Submit run. Intended for debugging and troubleshooting.
+// Falls back to the persisted result on disk when the in-memory state is empty.
 func (p *Process) ResultDetail() ResultDetailInfo {
 	p.mu.RLock()
-	defer p.mu.RUnlock()
-
-	return ResultDetailInfo{
+	detail := ResultDetailInfo{
 		ResultText:   p.result.text,
 		Messages:     p.result.messages,
 		MessageCount: len(p.result.messages),
@@ -436,6 +467,17 @@ func (p *Process) ResultDetail() ResultDetailInfo {
 		Status:       p.status,
 		ErrorMessage: p.lastError,
 	}
+	store := p.resultStore
+	p.mu.RUnlock()
+
+	// Fall back to disk when in-memory result is empty.
+	if detail.ResultText == "" && store != nil {
+		if pr, err := store.Load(); err == nil && pr != nil {
+			return pr.ToResultDetailInfo()
+		}
+	}
+
+	return detail
 }
 
 // Done returns a channel closed when the current run completes.

--- a/pkg/claude/resultstore.go
+++ b/pkg/claude/resultstore.go
@@ -1,0 +1,201 @@
+package claude
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const (
+	// DefaultResultDir is the subdirectory under the workspace where
+	// persisted results are stored.
+	DefaultResultDir = ".klaus"
+
+	// resultFileName is the name of the persisted result file.
+	resultFileName = "last-result.json"
+)
+
+// StopReason indicates why the agent stopped.
+type StopReason string
+
+const (
+	StopReasonCompleted StopReason = "completed"
+	StopReasonBudget    StopReason = "budget"
+	StopReasonError     StopReason = "error"
+	StopReasonStopped   StopReason = "stopped"
+)
+
+// PersistedResult is the on-disk representation of a session result.
+// It extends ResultDetailInfo with metadata for post-mortem retrieval.
+type PersistedResult struct {
+	ResultText   string          `json:"result_text"`
+	Messages     []StreamMessage `json:"messages,omitempty"`
+	MessageCount int             `json:"message_count"`
+	ToolCalls    map[string]int  `json:"tool_calls,omitempty"`
+	TotalCost    float64         `json:"total_cost_usd,omitempty"`
+	SessionID    string          `json:"session_id,omitempty"`
+	Status       ProcessStatus   `json:"status"`
+	ErrorMessage string          `json:"error,omitempty"`
+	StopReason   StopReason      `json:"stop_reason,omitempty"`
+	Timestamp    time.Time       `json:"timestamp"`
+}
+
+// ToResultDetailInfo converts a PersistedResult back to a ResultDetailInfo.
+func (pr *PersistedResult) ToResultDetailInfo() ResultDetailInfo {
+	return ResultDetailInfo{
+		ResultText:   pr.ResultText,
+		Messages:     pr.Messages,
+		MessageCount: pr.MessageCount,
+		ToolCalls:    pr.ToolCalls,
+		TotalCost:    pr.TotalCost,
+		SessionID:    pr.SessionID,
+		Status:       pr.Status,
+		ErrorMessage: pr.ErrorMessage,
+	}
+}
+
+// ResultStore persists session results to disk so they survive process
+// restarts. It writes JSON files to a well-known directory.
+type ResultStore struct {
+	dir string
+}
+
+// NewResultStore creates a ResultStore that writes to the given directory.
+// The directory is created on first Save if it doesn't exist.
+func NewResultStore(dir string) *ResultStore {
+	return &ResultStore{dir: dir}
+}
+
+// ResultStorePath returns the default result store directory for a workspace.
+func ResultStorePath(workDir string) string {
+	if workDir == "" {
+		workDir = "."
+	}
+	return filepath.Join(workDir, DefaultResultDir)
+}
+
+// Save persists a result to disk. It creates the directory if needed.
+// Save is not safe for concurrent use; callers must ensure single-writer
+// semantics (which is naturally provided by the drain goroutine pattern).
+func (s *ResultStore) Save(result PersistedResult) error {
+	if err := os.MkdirAll(s.dir, 0o700); err != nil {
+		return fmt.Errorf("creating result store directory: %w", err)
+	}
+
+	data, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling result: %w", err)
+	}
+
+	path := filepath.Join(s.dir, resultFileName)
+
+	// Write atomically via temp file + rename to avoid partial reads.
+	// Use CreateTemp for an unpredictable filename to prevent symlink attacks.
+	tmp, err := os.CreateTemp(s.dir, ".last-result-*.tmp")
+	if err != nil {
+		return fmt.Errorf("creating temp file: %w", err)
+	}
+	tmpName := tmp.Name()
+
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("writing result file: %w", err)
+	}
+	if err := tmp.Chmod(0o600); err != nil {
+		tmp.Close()
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("setting file permissions: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("closing temp file: %w", err)
+	}
+
+	if err := os.Rename(tmpName, path); err != nil {
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("renaming result file: %w", err)
+	}
+
+	return nil
+}
+
+// Load reads the persisted result from disk. Returns nil if no persisted
+// result exists. Returns an error for I/O or parse failures.
+func (s *ResultStore) Load() (*PersistedResult, error) {
+	path := filepath.Join(s.dir, resultFileName)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("reading result file: %w", err)
+	}
+
+	var result PersistedResult
+	if err := json.Unmarshal(data, &result); err != nil {
+		return nil, fmt.Errorf("parsing result file: %w", err)
+	}
+
+	return &result, nil
+}
+
+// persistResult is a helper called from the setResult callbacks in both
+// Process and PersistentProcess. It saves the result to disk if a store
+// is configured and the result is complete.
+func persistResult(store *ResultStore, rs resultState, status ProcessStatus, sessionID string, totalCost float64, lastError string) {
+	if store == nil || !rs.completed {
+		return
+	}
+
+	reason := stopReasonFromStatus(status)
+
+	pr := PersistedResult{
+		ResultText:   rs.text,
+		Messages:     rs.messages,
+		MessageCount: len(rs.messages),
+		ToolCalls:    collectToolCalls(rs.messages),
+		TotalCost:    totalCost,
+		SessionID:    sessionID,
+		Status:       status,
+		ErrorMessage: lastError,
+		StopReason:   reason,
+		Timestamp:    time.Now(),
+	}
+
+	if err := store.Save(pr); err != nil {
+		log.Printf("[klaus] failed to persist result: %v", err)
+	}
+}
+
+// stopReasonFromStatus maps a process status to a stop reason.
+func stopReasonFromStatus(status ProcessStatus) StopReason {
+	switch status {
+	case ProcessStatusCompleted, ProcessStatusIdle:
+		return StopReasonCompleted
+	case ProcessStatusStopped:
+		return StopReasonStopped
+	case ProcessStatusError:
+		return StopReasonError
+	default:
+		return StopReasonCompleted
+	}
+}
+
+// collectToolCalls extracts tool call counts from a set of messages.
+func collectToolCalls(messages []StreamMessage) map[string]int {
+	calls := make(map[string]int)
+	for _, msg := range messages {
+		if msg.Type == MessageTypeAssistant && msg.Subtype == SubtypeToolUse {
+			calls[msg.ToolName]++
+		}
+	}
+	if len(calls) == 0 {
+		return nil
+	}
+	return calls
+}

--- a/pkg/claude/resultstore_test.go
+++ b/pkg/claude/resultstore_test.go
@@ -1,0 +1,478 @@
+package claude
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestResultStore_SaveAndLoad(t *testing.T) {
+	dir := t.TempDir()
+	store := NewResultStore(dir)
+
+	pr := PersistedResult{
+		ResultText:   "Task completed successfully",
+		MessageCount: 5,
+		ToolCalls:    map[string]int{"Bash": 3, "Read": 2},
+		TotalCost:    0.15,
+		SessionID:    "sess-123",
+		Status:       ProcessStatusCompleted,
+		StopReason:   StopReasonCompleted,
+		Timestamp:    time.Now(),
+	}
+
+	if err := store.Save(pr); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	loaded, err := store.Load()
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	if loaded == nil {
+		t.Fatal("expected non-nil result")
+	}
+
+	if loaded.ResultText != pr.ResultText {
+		t.Errorf("expected ResultText %q, got %q", pr.ResultText, loaded.ResultText)
+	}
+	if loaded.MessageCount != pr.MessageCount {
+		t.Errorf("expected MessageCount %d, got %d", pr.MessageCount, loaded.MessageCount)
+	}
+	if loaded.TotalCost != pr.TotalCost {
+		t.Errorf("expected TotalCost %f, got %f", pr.TotalCost, loaded.TotalCost)
+	}
+	if loaded.SessionID != pr.SessionID {
+		t.Errorf("expected SessionID %q, got %q", pr.SessionID, loaded.SessionID)
+	}
+	if loaded.Status != pr.Status {
+		t.Errorf("expected Status %q, got %q", pr.Status, loaded.Status)
+	}
+	if loaded.StopReason != pr.StopReason {
+		t.Errorf("expected StopReason %q, got %q", pr.StopReason, loaded.StopReason)
+	}
+	if loaded.ToolCalls["Bash"] != 3 {
+		t.Errorf("expected ToolCalls[Bash]=3, got %d", loaded.ToolCalls["Bash"])
+	}
+	if loaded.ToolCalls["Read"] != 2 {
+		t.Errorf("expected ToolCalls[Read]=2, got %d", loaded.ToolCalls["Read"])
+	}
+}
+
+func TestResultStore_LoadNonExistent(t *testing.T) {
+	dir := t.TempDir()
+	store := NewResultStore(dir)
+
+	loaded, err := store.Load()
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	if loaded != nil {
+		t.Errorf("expected nil for non-existent result, got %v", loaded)
+	}
+}
+
+func TestResultStore_SaveCreatesDirectory(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "nested", "result", "dir")
+	store := NewResultStore(dir)
+
+	pr := PersistedResult{
+		ResultText: "hello",
+		Status:     ProcessStatusCompleted,
+		Timestamp:  time.Now(),
+	}
+
+	if err := store.Save(pr); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	// Verify directory was created.
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("directory not created: %v", err)
+	}
+	if !info.IsDir() {
+		t.Error("expected directory")
+	}
+}
+
+func TestResultStore_SaveOverwritesPrevious(t *testing.T) {
+	dir := t.TempDir()
+	store := NewResultStore(dir)
+
+	first := PersistedResult{
+		ResultText: "first result",
+		SessionID:  "sess-1",
+		Status:     ProcessStatusCompleted,
+		Timestamp:  time.Now(),
+	}
+	if err := store.Save(first); err != nil {
+		t.Fatalf("Save first failed: %v", err)
+	}
+
+	second := PersistedResult{
+		ResultText: "second result",
+		SessionID:  "sess-2",
+		Status:     ProcessStatusError,
+		StopReason: StopReasonError,
+		Timestamp:  time.Now(),
+	}
+	if err := store.Save(second); err != nil {
+		t.Fatalf("Save second failed: %v", err)
+	}
+
+	loaded, err := store.Load()
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	if loaded.ResultText != "second result" {
+		t.Errorf("expected second result, got %q", loaded.ResultText)
+	}
+	if loaded.SessionID != "sess-2" {
+		t.Errorf("expected sess-2, got %q", loaded.SessionID)
+	}
+}
+
+func TestResultStore_SaveWithMessages(t *testing.T) {
+	dir := t.TempDir()
+	store := NewResultStore(dir)
+
+	messages := []StreamMessage{
+		{Type: MessageTypeSystem, SessionID: "sess-abc"},
+		{Type: MessageTypeAssistant, Subtype: SubtypeText, Text: "Working..."},
+		{Type: MessageTypeAssistant, Subtype: SubtypeToolUse, ToolName: "Bash"},
+		{Type: MessageTypeResult, Result: "Done!", TotalCost: 0.10},
+	}
+
+	pr := PersistedResult{
+		ResultText:   "Done!",
+		Messages:     messages,
+		MessageCount: len(messages),
+		SessionID:    "sess-abc",
+		TotalCost:    0.10,
+		Status:       ProcessStatusCompleted,
+		StopReason:   StopReasonCompleted,
+		Timestamp:    time.Now(),
+	}
+
+	if err := store.Save(pr); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	loaded, err := store.Load()
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+
+	if len(loaded.Messages) != 4 {
+		t.Fatalf("expected 4 messages, got %d", len(loaded.Messages))
+	}
+	if loaded.Messages[0].SessionID != "sess-abc" {
+		t.Errorf("expected session_id in first message")
+	}
+	if loaded.Messages[3].Result != "Done!" {
+		t.Errorf("expected result in last message")
+	}
+}
+
+func TestResultStore_LoadCorruptFile(t *testing.T) {
+	dir := t.TempDir()
+	store := NewResultStore(dir)
+
+	// Write corrupt data.
+	path := filepath.Join(dir, resultFileName)
+	if err := os.WriteFile(path, []byte("not json"), 0o640); err != nil {
+		t.Fatalf("failed to write corrupt file: %v", err)
+	}
+
+	loaded, err := store.Load()
+	if err == nil {
+		t.Fatal("expected error for corrupt file")
+	}
+	if loaded != nil {
+		t.Errorf("expected nil result for corrupt file")
+	}
+}
+
+func TestPersistedResult_ToResultDetailInfo(t *testing.T) {
+	pr := PersistedResult{
+		ResultText:   "Full result",
+		MessageCount: 3,
+		ToolCalls:    map[string]int{"Bash": 2},
+		TotalCost:    0.25,
+		SessionID:    "sess-456",
+		Status:       ProcessStatusCompleted,
+		ErrorMessage: "",
+	}
+
+	detail := pr.ToResultDetailInfo()
+
+	if detail.ResultText != "Full result" {
+		t.Errorf("expected ResultText %q, got %q", "Full result", detail.ResultText)
+	}
+	if detail.MessageCount != 3 {
+		t.Errorf("expected MessageCount 3, got %d", detail.MessageCount)
+	}
+	if detail.SessionID != "sess-456" {
+		t.Errorf("expected SessionID %q, got %q", "sess-456", detail.SessionID)
+	}
+	if detail.TotalCost != 0.25 {
+		t.Errorf("expected TotalCost 0.25, got %f", detail.TotalCost)
+	}
+}
+
+func TestResultStorePath(t *testing.T) {
+	tests := []struct {
+		workDir  string
+		expected string
+	}{
+		{"/workspace", "/workspace/.klaus"},
+		{"", ".klaus"},
+		{"/home/user/project", "/home/user/project/.klaus"},
+	}
+
+	for _, tt := range tests {
+		got := ResultStorePath(tt.workDir)
+		if got != tt.expected {
+			t.Errorf("ResultStorePath(%q) = %q, want %q", tt.workDir, got, tt.expected)
+		}
+	}
+}
+
+func TestStopReasonFromStatus(t *testing.T) {
+	tests := []struct {
+		status   ProcessStatus
+		expected StopReason
+	}{
+		{ProcessStatusCompleted, StopReasonCompleted},
+		{ProcessStatusIdle, StopReasonCompleted},
+		{ProcessStatusStopped, StopReasonStopped},
+		{ProcessStatusError, StopReasonError},
+		{ProcessStatusBusy, StopReasonCompleted},
+	}
+
+	for _, tt := range tests {
+		got := stopReasonFromStatus(tt.status)
+		if got != tt.expected {
+			t.Errorf("stopReasonFromStatus(%q) = %q, want %q", tt.status, got, tt.expected)
+		}
+	}
+}
+
+func TestCollectToolCalls(t *testing.T) {
+	messages := []StreamMessage{
+		{Type: MessageTypeAssistant, Subtype: SubtypeToolUse, ToolName: "Bash"},
+		{Type: MessageTypeAssistant, Subtype: SubtypeText, Text: "hello"},
+		{Type: MessageTypeAssistant, Subtype: SubtypeToolUse, ToolName: "Bash"},
+		{Type: MessageTypeAssistant, Subtype: SubtypeToolUse, ToolName: "Read"},
+		{Type: MessageTypeResult, Result: "done"},
+	}
+
+	calls := collectToolCalls(messages)
+	if calls["Bash"] != 2 {
+		t.Errorf("expected Bash=2, got %d", calls["Bash"])
+	}
+	if calls["Read"] != 1 {
+		t.Errorf("expected Read=1, got %d", calls["Read"])
+	}
+}
+
+func TestCollectToolCalls_Empty(t *testing.T) {
+	calls := collectToolCalls(nil)
+	if calls != nil {
+		t.Errorf("expected nil for empty messages, got %v", calls)
+	}
+}
+
+func TestPersistResult_NilStore(t *testing.T) {
+	// Should not panic with nil store.
+	rs := resultState{text: "result", completed: true}
+	persistResult(nil, rs, ProcessStatusCompleted, "sess", 0.1, "")
+}
+
+func TestPersistResult_IncompleteResult(t *testing.T) {
+	dir := t.TempDir()
+	store := NewResultStore(dir)
+
+	// Incomplete result should not be persisted.
+	rs := resultState{text: "partial", completed: false}
+	persistResult(store, rs, ProcessStatusBusy, "sess", 0, "")
+
+	loaded, err := store.Load()
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	if loaded != nil {
+		t.Errorf("expected nil for incomplete result, got %v", loaded)
+	}
+}
+
+func TestPersistResult_CompletedResult(t *testing.T) {
+	dir := t.TempDir()
+	store := NewResultStore(dir)
+
+	rs := resultState{
+		text:      "final result",
+		messages:  []StreamMessage{{Type: MessageTypeResult, Result: "final result"}},
+		completed: true,
+	}
+	persistResult(store, rs, ProcessStatusCompleted, "sess-abc", 0.50, "")
+
+	loaded, err := store.Load()
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	if loaded == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if loaded.ResultText != "final result" {
+		t.Errorf("expected result %q, got %q", "final result", loaded.ResultText)
+	}
+	if loaded.SessionID != "sess-abc" {
+		t.Errorf("expected session_id %q, got %q", "sess-abc", loaded.SessionID)
+	}
+	if loaded.TotalCost != 0.50 {
+		t.Errorf("expected total_cost 0.50, got %f", loaded.TotalCost)
+	}
+	if loaded.StopReason != StopReasonCompleted {
+		t.Errorf("expected stop_reason %q, got %q", StopReasonCompleted, loaded.StopReason)
+	}
+}
+
+// TestProcess_StatusFallbackToDisk verifies that Status() falls back to
+// the persisted result when in-memory state is empty.
+func TestProcess_StatusFallbackToDisk(t *testing.T) {
+	dir := t.TempDir()
+	store := NewResultStore(dir)
+
+	// Pre-populate disk with a result.
+	pr := PersistedResult{
+		ResultText: "persisted result text",
+		SessionID:  "sess-persisted",
+		TotalCost:  1.23,
+		Status:     ProcessStatusCompleted,
+		StopReason: StopReasonCompleted,
+		Timestamp:  time.Now(),
+	}
+	if err := store.Save(pr); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	// Create a process with empty in-memory state but the same store.
+	p := NewProcess(Options{WorkDir: dir})
+	// Override the result store to point at our test dir.
+	p.resultStore = store
+
+	status := p.Status()
+	if status.Result != "persisted result text" {
+		t.Errorf("expected fallback result %q, got %q", "persisted result text", status.Result)
+	}
+	if status.SessionID != "sess-persisted" {
+		t.Errorf("expected fallback session_id %q, got %q", "sess-persisted", status.SessionID)
+	}
+	if status.TotalCost != 1.23 {
+		t.Errorf("expected fallback total_cost 1.23, got %f", status.TotalCost)
+	}
+}
+
+// TestProcess_ResultDetailFallbackToDisk verifies that ResultDetail()
+// falls back to the persisted result when in-memory state is empty.
+func TestProcess_ResultDetailFallbackToDisk(t *testing.T) {
+	dir := t.TempDir()
+	store := NewResultStore(dir)
+
+	pr := PersistedResult{
+		ResultText:   "full persisted result",
+		MessageCount: 10,
+		SessionID:    "sess-detail",
+		TotalCost:    2.50,
+		Status:       ProcessStatusCompleted,
+		Timestamp:    time.Now(),
+	}
+	if err := store.Save(pr); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	p := NewProcess(Options{WorkDir: dir})
+	p.resultStore = store
+
+	detail := p.ResultDetail()
+	if detail.ResultText != "full persisted result" {
+		t.Errorf("expected fallback result_text %q, got %q", "full persisted result", detail.ResultText)
+	}
+	if detail.SessionID != "sess-detail" {
+		t.Errorf("expected fallback session_id %q, got %q", "sess-detail", detail.SessionID)
+	}
+	if detail.TotalCost != 2.50 {
+		t.Errorf("expected fallback total_cost 2.50, got %f", detail.TotalCost)
+	}
+}
+
+// TestProcess_InMemoryResultTakesPrecedence verifies that in-memory
+// results are preferred over disk results.
+func TestProcess_InMemoryResultTakesPrecedence(t *testing.T) {
+	dir := t.TempDir()
+	store := NewResultStore(dir)
+
+	// Save an old result to disk.
+	pr := PersistedResult{
+		ResultText: "old persisted result",
+		SessionID:  "sess-old",
+		Status:     ProcessStatusCompleted,
+		Timestamp:  time.Now(),
+	}
+	if err := store.Save(pr); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	p := NewProcess(Options{WorkDir: dir})
+	p.resultStore = store
+
+	// Set in-memory result.
+	p.mu.Lock()
+	p.result = resultState{text: "fresh in-memory result", completed: true}
+	p.status = ProcessStatusCompleted
+	p.sessionID = "sess-fresh"
+	p.mu.Unlock()
+
+	status := p.Status()
+	if status.Result != "fresh in-memory result" {
+		t.Errorf("expected in-memory result %q, got %q", "fresh in-memory result", status.Result)
+	}
+	if status.SessionID != "sess-fresh" {
+		t.Errorf("expected in-memory session_id %q, got %q", "sess-fresh", status.SessionID)
+	}
+
+	detail := p.ResultDetail()
+	if detail.ResultText != "fresh in-memory result" {
+		t.Errorf("expected in-memory result_text %q, got %q", "fresh in-memory result", detail.ResultText)
+	}
+}
+
+func TestResultStore_AtomicWrite(t *testing.T) {
+	dir := t.TempDir()
+	store := NewResultStore(dir)
+
+	pr := PersistedResult{
+		ResultText: "test atomicity",
+		Status:     ProcessStatusCompleted,
+		Timestamp:  time.Now(),
+	}
+
+	if err := store.Save(pr); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	// Verify no .tmp file is left behind.
+	tmpPath := filepath.Join(dir, resultFileName+".tmp")
+	if _, err := os.Stat(tmpPath); !os.IsNotExist(err) {
+		t.Errorf("expected temp file to be cleaned up, but it exists")
+	}
+
+	// Verify the result file exists.
+	path := filepath.Join(dir, resultFileName)
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("expected result file to exist: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Add `ResultStore` that persists session results to `.klaus/last-result.json` in the workspace directory as JSON
- Both `Process` and `PersistentProcess` automatically persist results to disk when a Submit run completes
- `Status()` and `ResultDetail()` fall back to the persisted result when in-memory state is empty, enabling result retrieval after container restarts
- Include metadata in persisted results: timestamp, stop reason (completed/budget/error/stopped), session ID, cost, and full message history

## Details

When a klaus agent stops (budget exhaustion, error, or explicit stop), all work context was previously lost. Orchestrators calling the `result` or `status` MCP tools would get empty responses for stopped instances.

This change persists the result to disk before the in-memory state is cleared. The `status` and `result` tools transparently fall back to disk when no in-memory result is available.

**Security hardening based on review:**
- Atomic writes via `os.CreateTemp` + rename (prevents symlink attacks with predictable temp filenames)
- Restrictive file permissions: `0700` for directory, `0600` for files
- Disk I/O fallback skipped when process is actively running (busy/starting) to avoid unnecessary reads on hot polling paths

Closes #61

## Test plan

- [x] Unit tests for `ResultStore` (save/load, overwrite, corrupt file, directory creation, atomic write)
- [x] Unit tests for `persistResult` helper (nil store, incomplete result, completed result)
- [x] Integration tests for `Process.Status()` and `ResultDetail()` disk fallback
- [x] Integration test for in-memory result taking precedence over disk
- [x] Full test suite passes (`go test ./...`)

## Self-review

**code-reviewer**: No critical issues. Advisory findings addressed: disk I/O gated on non-busy status, single-writer contract documented on Save(), security fixes applied.

**security-auditor**: Medium findings addressed: symlink attack mitigated via `os.CreateTemp`, file permissions tightened to `0700`/`0600`. Remaining low-severity items (fsync, path validation) accepted as reasonable tradeoffs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)