### PR TITLE
feat: track subagent/Task dispatches in status and result

### DIFF
--- a/pkg/claude/message.go
+++ b/pkg/claude/message.go
@@ -101,6 +101,8 @@ type StatusInfo struct {
 	ToolCalls     map[string]int `json:"tool_calls,omitempty"`
 	LastMessage   string         `json:"last_message,omitempty"`
 	LastToolName  string         `json:"last_tool_name,omitempty"`
+	// SubagentCalls tracks subagent dispatches via the Task/Agent tool.
+	SubagentCalls []SubagentCall `json:"subagent_calls,omitempty"`
 	// Result contains the agent's final output text from the last completed
 	// non-blocking Submit run, truncated to maxStatusResultLen runes. It is
 	// populated when the status is "completed". Use the result debug tool
@@ -117,14 +119,26 @@ type StatusInfo struct {
 // from the last completed run. Intended for debugging and troubleshooting.
 // Unlike StatusInfo.Result, ResultText is never truncated.
 type ResultDetailInfo struct {
-	ResultText   string          `json:"result_text"`
-	Messages     []StreamMessage `json:"messages,omitempty"`
-	MessageCount int             `json:"message_count"`
-	ToolCalls    map[string]int  `json:"tool_calls,omitempty"`
-	TotalCost    float64         `json:"total_cost_usd,omitempty"`
-	SessionID    string          `json:"session_id,omitempty"`
-	Status       ProcessStatus   `json:"status"`
-	ErrorMessage string          `json:"error,omitempty"`
+	ResultText    string          `json:"result_text"`
+	Messages      []StreamMessage `json:"messages,omitempty"`
+	MessageCount  int             `json:"message_count"`
+	ToolCalls     map[string]int  `json:"tool_calls,omitempty"`
+	SubagentCalls []SubagentCall  `json:"subagent_calls,omitempty"`
+	TotalCost     float64         `json:"total_cost_usd,omitempty"`
+	SessionID     string          `json:"session_id,omitempty"`
+	Status        ProcessStatus   `json:"status"`
+	ErrorMessage  string          `json:"error,omitempty"`
+}
+
+// SubagentCall tracks a single subagent dispatch via the Task/Agent tool.
+type SubagentCall struct {
+	Type        string  `json:"type"`
+	Description string  `json:"description,omitempty"`
+	ToolID      string  `json:"tool_id,omitempty"`
+	ToolCalls   int     `json:"tool_calls,omitempty"`
+	Tokens      int     `json:"tokens,omitempty"`
+	DurationMS  float64 `json:"duration_ms,omitempty"`
+	Status      string  `json:"status,omitempty"`
 }
 
 // copyToolCalls returns a shallow copy of the map to avoid exposing internal

--- a/pkg/claude/persistent.go
+++ b/pkg/claude/persistent.go
@@ -35,6 +35,7 @@ type PersistentProcess struct {
 	toolCalls     map[string]int
 	lastMessage   string
 	lastToolName  string
+	subagents     *subagentTracker
 
 	// result stores the output of the last completed Submit run,
 	// allowing callers to retrieve results asynchronously.
@@ -77,6 +78,7 @@ func NewPersistentProcess(opts Options) *PersistentProcess {
 	return &PersistentProcess{
 		opts:        opts,
 		status:      ProcessStatusIdle,
+		subagents:   newSubagentTracker(),
 		done:        done,
 		processDone: processDone,
 		autoRestart: true,
@@ -280,7 +282,12 @@ func (p *PersistentProcess) readLoop(ctx context.Context, stdout io.ReadCloser, 
 				p.toolCallCount++
 				p.lastToolName = msg.ToolName
 				p.toolCalls[msg.ToolName]++
+				p.subagents.handleToolUse(msg)
+			} else {
+				p.subagents.handleMessage(msg)
 			}
+		} else {
+			p.subagents.handleMessage(msg)
 		}
 		// Compute the cost delta before overwriting the running total so we
 		// only add the incremental cost to the Prometheus counter.
@@ -393,6 +400,7 @@ func (p *PersistentProcess) RunWithOptions(ctx context.Context, prompt string, r
 	p.toolCalls = make(map[string]int)
 	p.lastMessage = ""
 	p.lastToolName = ""
+	p.subagents.reset()
 
 	// Create response channel and done channel for this prompt.
 	ch := make(chan StreamMessage, 100)
@@ -542,6 +550,7 @@ func (p *PersistentProcess) Status() StatusInfo {
 		ToolCalls:     copyToolCalls(p.toolCalls),
 		LastMessage:   p.lastMessage,
 		LastToolName:  p.lastToolName,
+		SubagentCalls: copySubagentCalls(p.subagents.calls()),
 	}
 
 	if p.status == ProcessStatusCompleted {
@@ -577,14 +586,15 @@ func (p *PersistentProcess) Status() StatusInfo {
 func (p *PersistentProcess) ResultDetail() ResultDetailInfo {
 	p.mu.RLock()
 	detail := ResultDetailInfo{
-		ResultText:   p.result.text,
-		Messages:     p.result.messages,
-		MessageCount: len(p.result.messages),
-		ToolCalls:    copyToolCalls(p.toolCalls),
-		TotalCost:    p.totalCost,
-		SessionID:    p.sessionID,
-		Status:       p.status,
-		ErrorMessage: p.lastError,
+		ResultText:    p.result.text,
+		Messages:      p.result.messages,
+		MessageCount:  len(p.result.messages),
+		ToolCalls:     copyToolCalls(p.toolCalls),
+		SubagentCalls: copySubagentCalls(p.subagents.calls()),
+		TotalCost:     p.totalCost,
+		SessionID:     p.sessionID,
+		Status:        p.status,
+		ErrorMessage:  p.lastError,
 	}
 	store := p.resultStore
 	p.mu.RUnlock()

--- a/pkg/claude/process.go
+++ b/pkg/claude/process.go
@@ -85,6 +85,7 @@ type Process struct {
 	toolCalls     map[string]int
 	lastMessage   string
 	lastToolName  string
+	subagents     *subagentTracker
 
 	// result stores the output of the last completed Submit run,
 	// allowing callers to retrieve results asynchronously.
@@ -106,6 +107,7 @@ func NewProcess(opts Options) *Process {
 	return &Process{
 		opts:        opts,
 		status:      ProcessStatusIdle,
+		subagents:   newSubagentTracker(),
 		done:        done,
 		resultStore: NewResultStore(ResultStorePath(opts.WorkDir)),
 	}
@@ -164,6 +166,7 @@ func (p *Process) RunWithOptions(ctx context.Context, prompt string, runOpts *Ru
 	p.toolCalls = make(map[string]int)
 	p.lastMessage = ""
 	p.lastToolName = ""
+	p.subagents.reset()
 
 	// Create a new done channel for this run while holding the lock,
 	// ensuring no race between concurrent callers.
@@ -282,7 +285,12 @@ func (p *Process) RunWithOptions(ctx context.Context, prompt string, runOpts *Ru
 					p.toolCallCount++
 					p.lastToolName = msg.ToolName
 					p.toolCalls[msg.ToolName]++
+					p.subagents.handleToolUse(msg)
+				} else {
+					p.subagents.handleMessage(msg)
 				}
+			} else {
+				p.subagents.handleMessage(msg)
 			}
 			if msg.Type == MessageTypeResult {
 				p.totalCost = msg.TotalCost
@@ -421,6 +429,7 @@ func (p *Process) Status() StatusInfo {
 		ToolCalls:     copyToolCalls(p.toolCalls),
 		LastMessage:   p.lastMessage,
 		LastToolName:  p.lastToolName,
+		SubagentCalls: copySubagentCalls(p.subagents.calls()),
 	}
 
 	if p.status == ProcessStatusCompleted {
@@ -458,14 +467,15 @@ func (p *Process) Status() StatusInfo {
 func (p *Process) ResultDetail() ResultDetailInfo {
 	p.mu.RLock()
 	detail := ResultDetailInfo{
-		ResultText:   p.result.text,
-		Messages:     p.result.messages,
-		MessageCount: len(p.result.messages),
-		ToolCalls:    copyToolCalls(p.toolCalls),
-		TotalCost:    p.totalCost,
-		SessionID:    p.sessionID,
-		Status:       p.status,
-		ErrorMessage: p.lastError,
+		ResultText:    p.result.text,
+		Messages:      p.result.messages,
+		MessageCount:  len(p.result.messages),
+		ToolCalls:     copyToolCalls(p.toolCalls),
+		SubagentCalls: copySubagentCalls(p.subagents.calls()),
+		TotalCost:     p.totalCost,
+		SessionID:     p.sessionID,
+		Status:        p.status,
+		ErrorMessage:  p.lastError,
 	}
 	store := p.resultStore
 	p.mu.RUnlock()

--- a/pkg/claude/resultstore.go
+++ b/pkg/claude/resultstore.go
@@ -31,29 +31,31 @@ const (
 // PersistedResult is the on-disk representation of a session result.
 // It extends ResultDetailInfo with metadata for post-mortem retrieval.
 type PersistedResult struct {
-	ResultText   string          `json:"result_text"`
-	Messages     []StreamMessage `json:"messages,omitempty"`
-	MessageCount int             `json:"message_count"`
-	ToolCalls    map[string]int  `json:"tool_calls,omitempty"`
-	TotalCost    float64         `json:"total_cost_usd,omitempty"`
-	SessionID    string          `json:"session_id,omitempty"`
-	Status       ProcessStatus   `json:"status"`
-	ErrorMessage string          `json:"error,omitempty"`
-	StopReason   StopReason      `json:"stop_reason,omitempty"`
-	Timestamp    time.Time       `json:"timestamp"`
+	ResultText    string          `json:"result_text"`
+	Messages      []StreamMessage `json:"messages,omitempty"`
+	MessageCount  int             `json:"message_count"`
+	ToolCalls     map[string]int  `json:"tool_calls,omitempty"`
+	SubagentCalls []SubagentCall  `json:"subagent_calls,omitempty"`
+	TotalCost     float64         `json:"total_cost_usd,omitempty"`
+	SessionID     string          `json:"session_id,omitempty"`
+	Status        ProcessStatus   `json:"status"`
+	ErrorMessage  string          `json:"error,omitempty"`
+	StopReason    StopReason      `json:"stop_reason,omitempty"`
+	Timestamp     time.Time       `json:"timestamp"`
 }
 
 // ToResultDetailInfo converts a PersistedResult back to a ResultDetailInfo.
 func (pr *PersistedResult) ToResultDetailInfo() ResultDetailInfo {
 	return ResultDetailInfo{
-		ResultText:   pr.ResultText,
-		Messages:     pr.Messages,
-		MessageCount: pr.MessageCount,
-		ToolCalls:    pr.ToolCalls,
-		TotalCost:    pr.TotalCost,
-		SessionID:    pr.SessionID,
-		Status:       pr.Status,
-		ErrorMessage: pr.ErrorMessage,
+		ResultText:    pr.ResultText,
+		Messages:      pr.Messages,
+		MessageCount:  pr.MessageCount,
+		ToolCalls:     pr.ToolCalls,
+		SubagentCalls: copySubagentCalls(pr.SubagentCalls),
+		TotalCost:     pr.TotalCost,
+		SessionID:     pr.SessionID,
+		Status:        pr.Status,
+		ErrorMessage:  pr.ErrorMessage,
 	}
 }
 
@@ -155,16 +157,17 @@ func persistResult(store *ResultStore, rs resultState, status ProcessStatus, ses
 	reason := stopReasonFromStatus(status)
 
 	pr := PersistedResult{
-		ResultText:   rs.text,
-		Messages:     rs.messages,
-		MessageCount: len(rs.messages),
-		ToolCalls:    collectToolCalls(rs.messages),
-		TotalCost:    totalCost,
-		SessionID:    sessionID,
-		Status:       status,
-		ErrorMessage: lastError,
-		StopReason:   reason,
-		Timestamp:    time.Now(),
+		ResultText:    rs.text,
+		Messages:      rs.messages,
+		MessageCount:  len(rs.messages),
+		ToolCalls:     collectToolCalls(rs.messages),
+		SubagentCalls: collectSubagentCalls(rs.messages),
+		TotalCost:     totalCost,
+		SessionID:     sessionID,
+		Status:        status,
+		ErrorMessage:  lastError,
+		StopReason:    reason,
+		Timestamp:     time.Now(),
 	}
 
 	if err := store.Save(pr); err != nil {

--- a/pkg/claude/subagent.go
+++ b/pkg/claude/subagent.go
@@ -1,0 +1,222 @@
+package claude
+
+import (
+	"encoding/json"
+	"log"
+	"regexp"
+	"strconv"
+	"time"
+)
+
+// taskToolNames is the set of tool names that represent subagent dispatches.
+// Claude Code uses "Task" in older versions and "Agent" in newer ones.
+var taskToolNames = map[string]bool{
+	"Task":  true,
+	"Agent": true,
+}
+
+// isSubagentTool returns true if the given tool name is a subagent dispatch tool.
+func isSubagentTool(toolName string) bool {
+	return taskToolNames[toolName]
+}
+
+// taskToolArgs represents the JSON arguments of a Task/Agent tool call.
+type taskToolArgs struct {
+	SubagentType string `json:"subagent_type"`
+	Description  string `json:"description"`
+}
+
+// maxInflightSubagents caps the number of concurrently tracked in-flight
+// subagent calls to prevent unbounded memory growth from a misbehaving
+// subprocess.
+const maxInflightSubagents = 100
+
+// subagentTracker manages in-flight subagent calls, matching tool_use messages
+// to their corresponding results to compute duration and extract metadata.
+type subagentTracker struct {
+	// inflight maps tool IDs to in-progress subagent calls with their start time.
+	inflight map[string]inflightSubagent
+
+	// completed holds finished subagent calls in dispatch order.
+	completed []SubagentCall
+
+	// seq is a monotonic counter used to order in-flight subagents
+	// deterministically when their start times are identical.
+	seq uint64
+}
+
+type inflightSubagent struct {
+	call  SubagentCall
+	start time.Time
+	seq   uint64
+}
+
+func newSubagentTracker() *subagentTracker {
+	return &subagentTracker{
+		inflight: make(map[string]inflightSubagent),
+	}
+}
+
+// handleToolUse processes a tool_use message. If the tool is a subagent dispatch,
+// it records the in-flight call and returns true.
+func (st *subagentTracker) handleToolUse(msg StreamMessage) bool {
+	if !isSubagentTool(msg.ToolName) {
+		return false
+	}
+
+	// Cap in-flight tracking to prevent unbounded growth.
+	if len(st.inflight) >= maxInflightSubagents {
+		log.Printf("[claude] subagent tracking limit reached (%d), ignoring new dispatch: %s",
+			maxInflightSubagents, msg.ToolID)
+		return false
+	}
+
+	call := SubagentCall{
+		ToolID: msg.ToolID,
+		Status: "running",
+	}
+
+	// Parse the tool arguments to extract subagent_type and description.
+	if len(msg.ToolArgs) > 0 {
+		var args taskToolArgs
+		if err := json.Unmarshal(msg.ToolArgs, &args); err == nil {
+			call.Type = args.SubagentType
+			call.Description = args.Description
+		}
+	}
+
+	if call.Type == "" {
+		call.Type = msg.ToolName
+	}
+
+	st.seq++
+	st.inflight[msg.ToolID] = inflightSubagent{
+		call:  call,
+		start: time.Now(),
+		seq:   st.seq,
+	}
+	return true
+}
+
+// usageBlockRe matches the <usage> block that Claude Code includes in subagent
+// tool results: total_tokens, tool_uses, and duration_ms.
+var usageBlockRe = regexp.MustCompile(
+	`<usage>\s*` +
+		`total_tokens:\s*(\d+)\s*` +
+		`tool_uses:\s*(\d+)\s*` +
+		`duration_ms:\s*(\d+)\s*` +
+		`</usage>`,
+)
+
+// handleMessage processes a non-tool_use stream message looking for subagent
+// result data via <usage> blocks in text content. Must NOT be called with
+// tool_use messages (use handleToolUse for those). Returns true if a subagent
+// was completed.
+func (st *subagentTracker) handleMessage(msg StreamMessage) bool {
+	if len(st.inflight) == 0 {
+		return false
+	}
+
+	// Look for <usage> blocks in text content that signal subagent completion.
+	// These appear in the tool result content returned by Claude Code.
+	content := msg.Text
+	if content == "" {
+		content = msg.Result
+	}
+	if content == "" {
+		return false
+	}
+
+	matches := usageBlockRe.FindStringSubmatch(content)
+	if len(matches) != 4 {
+		return false
+	}
+
+	// Match to the oldest in-flight subagent by sequence number (FIFO).
+	var oldestID string
+	var oldestInf inflightSubagent
+	for id, inf := range st.inflight {
+		if oldestID == "" || inf.seq < oldestInf.seq {
+			oldestID = id
+			oldestInf = inf
+		}
+	}
+	if oldestID == "" {
+		return false
+	}
+
+	st.completeSubagent(oldestID, oldestInf, content)
+	return true
+}
+
+func (st *subagentTracker) completeSubagent(toolID string, inf inflightSubagent, content string) {
+	delete(st.inflight, toolID)
+
+	call := inf.call
+	call.Status = "completed"
+	call.DurationMS = float64(time.Since(inf.start).Milliseconds())
+
+	// Try to parse the <usage> block from the result content.
+	if matches := usageBlockRe.FindStringSubmatch(content); len(matches) == 4 {
+		if tokens, err := strconv.Atoi(matches[1]); err == nil {
+			call.Tokens = tokens
+		}
+		if toolUses, err := strconv.Atoi(matches[2]); err == nil {
+			call.ToolCalls = toolUses
+		}
+		if durationMS, err := strconv.Atoi(matches[3]); err == nil {
+			call.DurationMS = float64(durationMS)
+		}
+	}
+
+	st.completed = append(st.completed, call)
+	log.Printf("[claude] subagent completed: type=%q description=%q tool_calls=%d tokens=%d duration_ms=%.0f",
+		call.Type, call.Description, call.ToolCalls, call.Tokens, call.DurationMS)
+}
+
+// calls returns a copy of all completed and in-flight subagent calls.
+// In-flight calls are appended after completed ones.
+func (st *subagentTracker) calls() []SubagentCall {
+	total := len(st.completed) + len(st.inflight)
+	if total == 0 {
+		return nil
+	}
+
+	result := make([]SubagentCall, 0, total)
+	result = append(result, st.completed...)
+	for _, inf := range st.inflight {
+		result = append(result, inf.call)
+	}
+	return result
+}
+
+// reset clears all tracking state.
+func (st *subagentTracker) reset() {
+	st.inflight = make(map[string]inflightSubagent)
+	st.completed = nil
+	st.seq = 0
+}
+
+// copySubagentCalls returns a shallow copy of the slice. Returns nil for nil/empty input.
+func copySubagentCalls(calls []SubagentCall) []SubagentCall {
+	if len(calls) == 0 {
+		return nil
+	}
+	cp := make([]SubagentCall, len(calls))
+	copy(cp, calls)
+	return cp
+}
+
+// collectSubagentCalls extracts subagent calls from a set of messages by
+// replaying them through a tracker. Used for persisted result reconstruction.
+func collectSubagentCalls(messages []StreamMessage) []SubagentCall {
+	tracker := newSubagentTracker()
+	for _, msg := range messages {
+		if msg.Type == MessageTypeAssistant && msg.Subtype == SubtypeToolUse {
+			tracker.handleToolUse(msg)
+		} else {
+			tracker.handleMessage(msg)
+		}
+	}
+	return tracker.calls()
+}

--- a/pkg/claude/subagent_test.go
+++ b/pkg/claude/subagent_test.go
@@ -1,0 +1,552 @@
+package claude
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestIsSubagentTool(t *testing.T) {
+	tests := []struct {
+		name string
+		tool string
+		want bool
+	}{
+		{"Task tool", "Task", true},
+		{"Agent tool", "Agent", true},
+		{"Bash tool", "Bash", false},
+		{"Read tool", "Read", false},
+		{"empty", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isSubagentTool(tt.tool); got != tt.want {
+				t.Errorf("isSubagentTool(%q) = %v, want %v", tt.tool, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSubagentTracker_HandleToolUse(t *testing.T) {
+	t.Run("records Task tool_use as inflight subagent", func(t *testing.T) {
+		tracker := newSubagentTracker()
+
+		args, _ := json.Marshal(taskToolArgs{
+			SubagentType: "Explore",
+			Description:  "Explore codebase structure",
+		})
+
+		msg := StreamMessage{
+			Type:     MessageTypeAssistant,
+			Subtype:  SubtypeToolUse,
+			ToolName: "Task",
+			ToolID:   "tool-1",
+			ToolArgs: args,
+		}
+
+		ok := tracker.handleToolUse(msg)
+		if !ok {
+			t.Error("expected handleToolUse to return true for Task tool")
+		}
+
+		calls := tracker.calls()
+		if len(calls) != 1 {
+			t.Fatalf("expected 1 call, got %d", len(calls))
+		}
+		if calls[0].Type != "Explore" {
+			t.Errorf("expected type %q, got %q", "Explore", calls[0].Type)
+		}
+		if calls[0].Description != "Explore codebase structure" {
+			t.Errorf("expected description %q, got %q", "Explore codebase structure", calls[0].Description)
+		}
+		if calls[0].Status != "running" {
+			t.Errorf("expected status %q, got %q", "running", calls[0].Status)
+		}
+		if calls[0].ToolID != "tool-1" {
+			t.Errorf("expected tool_id %q, got %q", "tool-1", calls[0].ToolID)
+		}
+	})
+
+	t.Run("ignores non-subagent tools", func(t *testing.T) {
+		tracker := newSubagentTracker()
+
+		msg := StreamMessage{
+			Type:     MessageTypeAssistant,
+			Subtype:  SubtypeToolUse,
+			ToolName: "Bash",
+			ToolID:   "tool-2",
+		}
+
+		ok := tracker.handleToolUse(msg)
+		if ok {
+			t.Error("expected handleToolUse to return false for Bash tool")
+		}
+		if len(tracker.calls()) != 0 {
+			t.Error("expected no calls tracked")
+		}
+	})
+
+	t.Run("handles Agent tool", func(t *testing.T) {
+		tracker := newSubagentTracker()
+
+		args, _ := json.Marshal(taskToolArgs{
+			SubagentType: "general-purpose",
+			Description:  "Research topic",
+		})
+
+		msg := StreamMessage{
+			Type:     MessageTypeAssistant,
+			Subtype:  SubtypeToolUse,
+			ToolName: "Agent",
+			ToolID:   "tool-3",
+			ToolArgs: args,
+		}
+
+		ok := tracker.handleToolUse(msg)
+		if !ok {
+			t.Error("expected handleToolUse to return true for Agent tool")
+		}
+
+		calls := tracker.calls()
+		if len(calls) != 1 {
+			t.Fatalf("expected 1 call, got %d", len(calls))
+		}
+		if calls[0].Type != "general-purpose" {
+			t.Errorf("expected type %q, got %q", "general-purpose", calls[0].Type)
+		}
+	})
+
+	t.Run("falls back to tool name when subagent_type is empty", func(t *testing.T) {
+		tracker := newSubagentTracker()
+
+		msg := StreamMessage{
+			Type:     MessageTypeAssistant,
+			Subtype:  SubtypeToolUse,
+			ToolName: "Task",
+			ToolID:   "tool-4",
+			ToolArgs: json.RawMessage(`{}`),
+		}
+
+		tracker.handleToolUse(msg)
+		calls := tracker.calls()
+		if len(calls) != 1 {
+			t.Fatalf("expected 1 call, got %d", len(calls))
+		}
+		if calls[0].Type != "Task" {
+			t.Errorf("expected type %q, got %q", "Task", calls[0].Type)
+		}
+	})
+}
+
+func TestSubagentTracker_HandleMessage_WithUsageBlock(t *testing.T) {
+	tracker := newSubagentTracker()
+
+	// First, record an inflight subagent.
+	args, _ := json.Marshal(taskToolArgs{
+		SubagentType: "Explore",
+		Description:  "Explore codebase",
+	})
+	tracker.handleToolUse(StreamMessage{
+		Type:     MessageTypeAssistant,
+		Subtype:  SubtypeToolUse,
+		ToolName: "Task",
+		ToolID:   "tool-1",
+		ToolArgs: args,
+	})
+
+	// Simulate a message containing the <usage> block.
+	usageText := `Some result text
+<usage>
+total_tokens: 36568
+tool_uses: 29
+duration_ms: 43095
+</usage>
+`
+
+	ok := tracker.handleMessage(StreamMessage{
+		Type: MessageTypeAssistant,
+		Text: usageText,
+	})
+	if !ok {
+		t.Error("expected handleMessage to return true when usage block found")
+	}
+
+	calls := tracker.calls()
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 completed call, got %d", len(calls))
+	}
+
+	call := calls[0]
+	if call.Status != "completed" {
+		t.Errorf("expected status %q, got %q", "completed", call.Status)
+	}
+	if call.Tokens != 36568 {
+		t.Errorf("expected tokens 36568, got %d", call.Tokens)
+	}
+	if call.ToolCalls != 29 {
+		t.Errorf("expected tool_calls 29, got %d", call.ToolCalls)
+	}
+	if call.DurationMS != 43095 {
+		t.Errorf("expected duration_ms 43095, got %f", call.DurationMS)
+	}
+	if call.Type != "Explore" {
+		t.Errorf("expected type %q, got %q", "Explore", call.Type)
+	}
+
+	// Inflight should be empty now.
+	if len(tracker.inflight) != 0 {
+		t.Errorf("expected 0 inflight, got %d", len(tracker.inflight))
+	}
+}
+
+func TestSubagentTracker_HandleMessage_NoInflight(t *testing.T) {
+	tracker := newSubagentTracker()
+
+	ok := tracker.handleMessage(StreamMessage{
+		Type: MessageTypeAssistant,
+		Text: "<usage>\ntotal_tokens: 100\ntool_uses: 5\nduration_ms: 1000\n</usage>",
+	})
+	if ok {
+		t.Error("expected handleMessage to return false when no inflight subagents")
+	}
+}
+
+func TestSubagentTracker_HandleMessage_NoUsageBlock(t *testing.T) {
+	tracker := newSubagentTracker()
+
+	// Add an inflight subagent.
+	tracker.handleToolUse(StreamMessage{
+		Type:     MessageTypeAssistant,
+		Subtype:  SubtypeToolUse,
+		ToolName: "Task",
+		ToolID:   "tool-1",
+	})
+
+	// Message without usage block should not complete the subagent.
+	ok := tracker.handleMessage(StreamMessage{
+		Type: MessageTypeAssistant,
+		Text: "Just some regular text",
+	})
+	if ok {
+		t.Error("expected handleMessage to return false for message without usage block")
+	}
+
+	// Still inflight.
+	calls := tracker.calls()
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(calls))
+	}
+	if calls[0].Status != "running" {
+		t.Errorf("expected status %q, got %q", "running", calls[0].Status)
+	}
+}
+
+func TestSubagentTracker_MultipleSubagents(t *testing.T) {
+	tracker := newSubagentTracker()
+
+	// Dispatch two subagents.
+	args1, _ := json.Marshal(taskToolArgs{SubagentType: "Explore", Description: "First"})
+	args2, _ := json.Marshal(taskToolArgs{SubagentType: "general-purpose", Description: "Second"})
+
+	tracker.handleToolUse(StreamMessage{
+		Type: MessageTypeAssistant, Subtype: SubtypeToolUse,
+		ToolName: "Task", ToolID: "tool-1", ToolArgs: args1,
+	})
+	tracker.handleToolUse(StreamMessage{
+		Type: MessageTypeAssistant, Subtype: SubtypeToolUse,
+		ToolName: "Agent", ToolID: "tool-2", ToolArgs: args2,
+	})
+
+	if len(tracker.calls()) != 2 {
+		t.Fatalf("expected 2 inflight calls, got %d", len(tracker.calls()))
+	}
+
+	// Complete the first one via usage block.
+	tracker.handleMessage(StreamMessage{
+		Type: MessageTypeAssistant,
+		Text: "<usage>\ntotal_tokens: 1000\ntool_uses: 10\nduration_ms: 5000\n</usage>",
+	})
+
+	// One completed, one still inflight.
+	calls := tracker.calls()
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 total calls, got %d", len(calls))
+	}
+
+	completedCount := 0
+	runningCount := 0
+	for _, c := range calls {
+		switch c.Status {
+		case "completed":
+			completedCount++
+		case "running":
+			runningCount++
+		}
+	}
+	if completedCount != 1 {
+		t.Errorf("expected 1 completed, got %d", completedCount)
+	}
+	if runningCount != 1 {
+		t.Errorf("expected 1 running, got %d", runningCount)
+	}
+}
+
+func TestSubagentTracker_Reset(t *testing.T) {
+	tracker := newSubagentTracker()
+
+	tracker.handleToolUse(StreamMessage{
+		Type: MessageTypeAssistant, Subtype: SubtypeToolUse,
+		ToolName: "Task", ToolID: "tool-1",
+	})
+
+	tracker.reset()
+
+	if len(tracker.calls()) != 0 {
+		t.Error("expected 0 calls after reset")
+	}
+	if len(tracker.inflight) != 0 {
+		t.Error("expected 0 inflight after reset")
+	}
+	if len(tracker.completed) != 0 {
+		t.Error("expected 0 completed after reset")
+	}
+}
+
+func TestCopySubagentCalls(t *testing.T) {
+	t.Run("nil returns nil", func(t *testing.T) {
+		if got := copySubagentCalls(nil); got != nil {
+			t.Errorf("expected nil, got %v", got)
+		}
+	})
+
+	t.Run("empty returns nil", func(t *testing.T) {
+		if got := copySubagentCalls([]SubagentCall{}); got != nil {
+			t.Errorf("expected nil, got %v", got)
+		}
+	})
+
+	t.Run("returns independent copy", func(t *testing.T) {
+		original := []SubagentCall{
+			{Type: "Explore", Description: "test", Tokens: 100},
+		}
+		cp := copySubagentCalls(original)
+		cp[0].Tokens = 999
+		if original[0].Tokens != 100 {
+			t.Errorf("expected original unchanged, got Tokens=%d", original[0].Tokens)
+		}
+	})
+}
+
+func TestCollectSubagentCalls(t *testing.T) {
+	args, _ := json.Marshal(taskToolArgs{
+		SubagentType: "Explore",
+		Description:  "Explore codebase",
+	})
+
+	messages := []StreamMessage{
+		{Type: MessageTypeSystem, SessionID: "sess-1"},
+		{Type: MessageTypeAssistant, Subtype: SubtypeToolUse, ToolName: "Task", ToolID: "t1", ToolArgs: args},
+		{Type: MessageTypeAssistant, Subtype: SubtypeText, Text: "<usage>\ntotal_tokens: 5000\ntool_uses: 15\nduration_ms: 10000\n</usage>"},
+		{Type: MessageTypeAssistant, Subtype: SubtypeToolUse, ToolName: "Bash", ToolID: "t2"},
+		{Type: MessageTypeResult, Result: "done"},
+	}
+
+	calls := collectSubagentCalls(messages)
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 subagent call, got %d", len(calls))
+	}
+	if calls[0].Type != "Explore" {
+		t.Errorf("expected type %q, got %q", "Explore", calls[0].Type)
+	}
+	if calls[0].Tokens != 5000 {
+		t.Errorf("expected tokens 5000, got %d", calls[0].Tokens)
+	}
+	if calls[0].ToolCalls != 15 {
+		t.Errorf("expected tool_calls 15, got %d", calls[0].ToolCalls)
+	}
+}
+
+func TestCollectSubagentCalls_NoSubagents(t *testing.T) {
+	messages := []StreamMessage{
+		{Type: MessageTypeAssistant, Subtype: SubtypeToolUse, ToolName: "Bash", ToolID: "t1"},
+		{Type: MessageTypeResult, Result: "done"},
+	}
+
+	calls := collectSubagentCalls(messages)
+	if calls != nil {
+		t.Errorf("expected nil, got %v", calls)
+	}
+}
+
+func TestUsageBlockRegex(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		tokens  string
+		tools   string
+		durMs   string
+		matches bool
+	}{
+		{
+			name:    "standard format",
+			input:   "<usage>\ntotal_tokens: 36568\ntool_uses: 29\nduration_ms: 43095\n</usage>",
+			tokens:  "36568",
+			tools:   "29",
+			durMs:   "43095",
+			matches: true,
+		},
+		{
+			name:    "embedded in text",
+			input:   "Result\n<usage>\ntotal_tokens: 100\ntool_uses: 5\nduration_ms: 2000\n</usage>\nMore text",
+			tokens:  "100",
+			tools:   "5",
+			durMs:   "2000",
+			matches: true,
+		},
+		{
+			name:    "no usage block",
+			input:   "just regular text",
+			matches: false,
+		},
+		{
+			name:    "partial usage block",
+			input:   "<usage>\ntotal_tokens: 100\n</usage>",
+			matches: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matches := usageBlockRe.FindStringSubmatch(tt.input)
+			if tt.matches {
+				if len(matches) != 4 {
+					t.Fatalf("expected 4 matches, got %d", len(matches))
+				}
+				if matches[1] != tt.tokens {
+					t.Errorf("expected tokens %q, got %q", tt.tokens, matches[1])
+				}
+				if matches[2] != tt.tools {
+					t.Errorf("expected tools %q, got %q", tt.tools, matches[2])
+				}
+				if matches[3] != tt.durMs {
+					t.Errorf("expected duration_ms %q, got %q", tt.durMs, matches[3])
+				}
+			} else if len(matches) > 0 {
+				t.Errorf("expected no match, got %v", matches)
+			}
+		})
+	}
+}
+
+func TestSubagentCallJSON(t *testing.T) {
+	call := SubagentCall{
+		Type:        "Explore",
+		Description: "Explore codebase structure",
+		ToolID:      "tool-1",
+		ToolCalls:   29,
+		Tokens:      36568,
+		DurationMS:  43095,
+		Status:      "completed",
+	}
+
+	data, err := json.Marshal(call)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var parsed SubagentCall
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if parsed.Type != "Explore" {
+		t.Errorf("expected type %q, got %q", "Explore", parsed.Type)
+	}
+	if parsed.Tokens != 36568 {
+		t.Errorf("expected tokens 36568, got %d", parsed.Tokens)
+	}
+	if parsed.ToolCalls != 29 {
+		t.Errorf("expected tool_calls 29, got %d", parsed.ToolCalls)
+	}
+	if parsed.DurationMS != 43095 {
+		t.Errorf("expected duration_ms 43095, got %f", parsed.DurationMS)
+	}
+}
+
+func TestSubagentCallOmittedFromStatusWhenEmpty(t *testing.T) {
+	process := NewProcess(DefaultOptions())
+
+	data, err := process.MarshalStatus()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	if _, exists := raw["subagent_calls"]; exists {
+		t.Error("expected subagent_calls to be omitted from JSON when empty")
+	}
+}
+
+func TestProcess_StatusIncludesSubagentCalls(t *testing.T) {
+	process := NewProcess(DefaultOptions())
+
+	// Simulate subagent tracking.
+	process.mu.Lock()
+	process.status = ProcessStatusBusy
+	args, _ := json.Marshal(taskToolArgs{SubagentType: "Explore", Description: "test"})
+	process.subagents.handleToolUse(StreamMessage{
+		Type: MessageTypeAssistant, Subtype: SubtypeToolUse,
+		ToolName: "Task", ToolID: "t1", ToolArgs: args,
+	})
+	process.subagents.handleMessage(StreamMessage{
+		Type: MessageTypeAssistant,
+		Text: "<usage>\ntotal_tokens: 5000\ntool_uses: 10\nduration_ms: 3000\n</usage>",
+	})
+	process.mu.Unlock()
+
+	status := process.Status()
+	if len(status.SubagentCalls) != 1 {
+		t.Fatalf("expected 1 subagent call, got %d", len(status.SubagentCalls))
+	}
+	if status.SubagentCalls[0].Type != "Explore" {
+		t.Errorf("expected type %q, got %q", "Explore", status.SubagentCalls[0].Type)
+	}
+	if status.SubagentCalls[0].Tokens != 5000 {
+		t.Errorf("expected tokens 5000, got %d", status.SubagentCalls[0].Tokens)
+	}
+
+	// Verify returned slice is a copy.
+	status.SubagentCalls[0].Tokens = 999
+	status2 := process.Status()
+	if status2.SubagentCalls[0].Tokens != 5000 {
+		t.Errorf("expected internal state to be unchanged, got tokens=%d", status2.SubagentCalls[0].Tokens)
+	}
+}
+
+func TestProcess_ResultDetailIncludesSubagentCalls(t *testing.T) {
+	process := NewProcess(DefaultOptions())
+
+	process.mu.Lock()
+	process.status = ProcessStatusCompleted
+	process.result = resultState{text: "done", completed: true}
+	args, _ := json.Marshal(taskToolArgs{SubagentType: "Explore", Description: "test"})
+	process.subagents.handleToolUse(StreamMessage{
+		Type: MessageTypeAssistant, Subtype: SubtypeToolUse,
+		ToolName: "Task", ToolID: "t1", ToolArgs: args,
+	})
+	process.subagents.handleMessage(StreamMessage{
+		Type: MessageTypeAssistant,
+		Text: "<usage>\ntotal_tokens: 2000\ntool_uses: 5\nduration_ms: 1000\n</usage>",
+	})
+	process.mu.Unlock()
+
+	detail := process.ResultDetail()
+	if len(detail.SubagentCalls) != 1 {
+		t.Fatalf("expected 1 subagent call, got %d", len(detail.SubagentCalls))
+	}
+	if detail.SubagentCalls[0].Tokens != 2000 {
+		t.Errorf("expected tokens 2000, got %d", detail.SubagentCalls[0].Tokens)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `SubagentCall` tracking to `StatusInfo`, `ResultDetailInfo`, and `PersistedResult`
- Detects Task/Agent tool dispatches in the stream-json output, parses subagent type and description from tool arguments
- Matches `<usage>` blocks in subsequent messages to capture token count, tool call count, and duration
- Includes the `subagent_calls` array in status, result detail, and persisted result JSON responses

Closes #83

## Implementation details

**New file:** `pkg/claude/subagent.go` — contains the `subagentTracker` type that manages in-flight and completed subagent calls. It uses a sequence counter for deterministic FIFO matching and caps in-flight tracking at 100 entries to prevent unbounded growth.

**Modified files:**
- `pkg/claude/message.go` — adds `SubagentCall` type and `SubagentCalls` field to `StatusInfo` and `ResultDetailInfo`
- `pkg/claude/process.go` — integrates tracker into single-shot `Process` stream loop, `Status()`, and `ResultDetail()`
- `pkg/claude/persistent.go` — integrates tracker into `PersistentProcess` read loop, `Status()`, and `ResultDetail()`
- `pkg/claude/resultstore.go` — adds `SubagentCalls` to `PersistedResult` and `persistResult` with replay via `collectSubagentCalls`

## Example JSON output

```json
{
  "status": "busy",
  "subagent_calls": [
    {
      "type": "Explore",
      "description": "Explore codebase structure",
      "tool_id": "tool-abc123",
      "tool_calls": 29,
      "tokens": 36568,
      "duration_ms": 43095,
      "status": "completed"
    }
  ]
}
```

## Test plan

- [x] Unit tests for `subagentTracker` (handleToolUse, handleMessage, usage block parsing, FIFO matching, reset, multiple subagents)
- [x] Unit tests for `SubagentCall` JSON serialization and omitempty behavior
- [x] Integration tests verifying `Process.Status()` and `Process.ResultDetail()` include subagent calls
- [x] Tests for `copySubagentCalls` and `collectSubagentCalls` helpers
- [x] Regex tests for `<usage>` block parsing with various formats
- [x] Full test suite passes (all packages)

## Self-review

**Code review (base:code-reviewer):** No critical bugs in final version. Addressed initial findings: removed dead ToolID-matching branch, eliminated double-dispatch fragility, added sequence counter for deterministic FIFO ordering, added inflight cap, added `</usage>` closing tag to regex, and ensured `copySubagentCalls` in `ToResultDetailInfo`.

**Security audit (code-quality:security-auditor):** No high/critical vulnerabilities. Regex is ReDoS-safe (RE2 engine). JSON unmarshaling is bounded to a two-field struct. Memory growth is capped at 100 inflight entries per run. All tracker access is properly synchronized under the parent process mutex. File persistence inherits existing 0600/atomic-write patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)