### PR TITLE
Fix: filter PR URL extraction to Bash tool results only (#123)

### DIFF
--- a/pkg/claude/extract_test.go
+++ b/pkg/claude/extract_test.go
@@ -280,29 +280,131 @@ func TestCollectModelUsage(t *testing.T) {
 }
 
 func TestCollectPRURLs(t *testing.T) {
-	messages := []StreamMessage{
-		{
-			Message: json.RawMessage(`{"content":[{"type":"tool_result","content":"Created PR: https://github.com/owner/repo/pull/42","is_error":false}]}`),
-		},
-		{
-			Message: json.RawMessage(`{"content":[{"type":"tool_result","content":"Also: https://github.com/owner/repo/pull/42 and https://github.com/other/repo/pull/7","is_error":false}]}`),
-		},
-	}
+	t.Run("legacy blocks without tool_use_id", func(t *testing.T) {
+		messages := []StreamMessage{
+			{
+				Message: json.RawMessage(`{"content":[{"type":"tool_result","content":"Created PR: https://github.com/owner/repo/pull/42","is_error":false}]}`),
+			},
+			{
+				Message: json.RawMessage(`{"content":[{"type":"tool_result","content":"Also: https://github.com/owner/repo/pull/42 and https://github.com/other/repo/pull/7","is_error":false}]}`),
+			},
+		}
 
-	urls := CollectPRURLs(messages)
-	if len(urls) != 2 {
-		t.Fatalf("CollectPRURLs() returned %d URLs, want 2", len(urls))
-	}
-	if urls[0] != "https://github.com/owner/repo/pull/42" {
-		t.Errorf("urls[0] = %q", urls[0])
-	}
-	if urls[1] != "https://github.com/other/repo/pull/7" {
-		t.Errorf("urls[1] = %q", urls[1])
-	}
+		urls := CollectPRURLs(messages)
+		if len(urls) != 2 {
+			t.Fatalf("CollectPRURLs() returned %d URLs, want 2", len(urls))
+		}
+		if urls[0] != "https://github.com/owner/repo/pull/42" {
+			t.Errorf("urls[0] = %q", urls[0])
+		}
+		if urls[1] != "https://github.com/other/repo/pull/7" {
+			t.Errorf("urls[1] = %q", urls[1])
+		}
+	})
 
-	// Empty returns nil.
-	if got := CollectPRURLs(nil); got != nil {
-		t.Errorf("CollectPRURLs(nil) = %v, want nil", got)
+	t.Run("extracts PR URLs from Bash tool results", func(t *testing.T) {
+		messages := []StreamMessage{
+			// Assistant invokes Bash tool.
+			{
+				Type:     MessageTypeAssistant,
+				Subtype:  SubtypeToolUse,
+				ToolName: "Bash",
+				ToolID:   "tool_bash_1",
+			},
+			// Tool result from Bash with a PR URL.
+			{
+				Message: json.RawMessage(`{"content":[{"type":"tool_result","tool_use_id":"tool_bash_1","content":"https://github.com/owner/repo/pull/99","is_error":false}]}`),
+			},
+		}
+
+		urls := CollectPRURLs(messages)
+		if len(urls) != 1 {
+			t.Fatalf("CollectPRURLs() returned %d URLs, want 1", len(urls))
+		}
+		if urls[0] != "https://github.com/owner/repo/pull/99" {
+			t.Errorf("urls[0] = %q", urls[0])
+		}
+	})
+
+	t.Run("ignores PR URLs from Read tool results", func(t *testing.T) {
+		messages := []StreamMessage{
+			// Assistant invokes Read tool.
+			{
+				Type:     MessageTypeAssistant,
+				Subtype:  SubtypeToolUse,
+				ToolName: "Read",
+				ToolID:   "tool_read_1",
+			},
+			// Tool result from Read containing a PR URL in file content.
+			{
+				Message: json.RawMessage(`{"content":[{"type":"tool_result","tool_use_id":"tool_read_1","content":"Test fixture: https://github.com/owner/repo/pull/42","is_error":false}]}`),
+			},
+		}
+
+		urls := CollectPRURLs(messages)
+		if urls != nil {
+			t.Errorf("CollectPRURLs() = %v, want nil (Read tool results should be ignored)", urls)
+		}
+	})
+
+	t.Run("mixed Bash and Read results", func(t *testing.T) {
+		messages := []StreamMessage{
+			// Bash tool_use
+			{
+				Type:     MessageTypeAssistant,
+				Subtype:  SubtypeToolUse,
+				ToolName: "Bash",
+				ToolID:   "tool_bash_1",
+			},
+			// Read tool_use
+			{
+				Type:     MessageTypeAssistant,
+				Subtype:  SubtypeToolUse,
+				ToolName: "Read",
+				ToolID:   "tool_read_1",
+			},
+			// Bash result with real PR URL.
+			{
+				Message: json.RawMessage(`{"content":[{"type":"tool_result","tool_use_id":"tool_bash_1","content":"Created https://github.com/owner/repo/pull/10","is_error":false}]}`),
+			},
+			// Read result with PR URL in file content (should be ignored).
+			{
+				Message: json.RawMessage(`{"content":[{"type":"tool_result","tool_use_id":"tool_read_1","content":"docs mention https://github.com/owner/repo/pull/999","is_error":false}]}`),
+			},
+		}
+
+		urls := CollectPRURLs(messages)
+		if len(urls) != 1 {
+			t.Fatalf("CollectPRURLs() returned %d URLs, want 1", len(urls))
+		}
+		if urls[0] != "https://github.com/owner/repo/pull/10" {
+			t.Errorf("urls[0] = %q, want https://github.com/owner/repo/pull/10", urls[0])
+		}
+	})
+
+	t.Run("nil returns nil", func(t *testing.T) {
+		if got := CollectPRURLs(nil); got != nil {
+			t.Errorf("CollectPRURLs(nil) = %v, want nil", got)
+		}
+	})
+}
+
+func TestIsBashTool(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{"Bash", true},
+		{"bash", true},
+		{"Read", false},
+		{"Write", false},
+		{"Edit", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		if got := isBashTool(tt.name); got != tt.want {
+			t.Errorf("isBashTool(%q) = %v, want %v", tt.name, got, tt.want)
+		}
 	}
 }
 

--- a/pkg/claude/message.go
+++ b/pkg/claude/message.go
@@ -181,9 +181,10 @@ type messageContentEnvelope struct {
 
 // ToolResultBlock represents a single content block from a user message (tool result).
 type ToolResultBlock struct {
-	Type    string `json:"type"`
-	Content string `json:"content"`
-	IsError bool   `json:"is_error"`
+	Type      string `json:"type"`
+	ToolUseID string `json:"tool_use_id,omitempty"`
+	Content   string `json:"content"`
+	IsError   bool   `json:"is_error"`
 }
 
 // prURLPattern matches GitHub pull request URLs in tool result content.
@@ -225,6 +226,13 @@ func ExtractToolResults(msg StreamMessage) []ToolResultBlock {
 		}
 	}
 	return results
+}
+
+// isBashTool reports whether the given tool name refers to a Bash/shell tool
+// whose output may contain real PR URLs (as opposed to file content tools like
+// Read/Write that may contain PR URLs embedded in source code or docs).
+func isBashTool(name string) bool {
+	return name == "Bash" || name == "bash"
 }
 
 // maxPRURLsPerBlock caps the number of PR URLs extracted from a single content block.
@@ -287,12 +295,30 @@ func CollectModelUsage(messages []StreamMessage) map[string]int {
 	return usage
 }
 
-// CollectPRURLs extracts unique GitHub PR URLs from tool_result content blocks.
+// CollectPRURLs extracts unique GitHub PR URLs from tool_result content blocks
+// that correspond to Bash/shell tool invocations. Tool results from file-reading
+// tools (Read, Write, etc.) are skipped to avoid false positives from PR URLs
+// embedded in source code or documentation.
 func CollectPRURLs(messages []StreamMessage) []string {
+	// Build a map from tool_use_id to tool_name by scanning assistant tool_use messages.
+	toolNames := make(map[string]string)
+	for _, msg := range messages {
+		if msg.Type == MessageTypeAssistant && msg.Subtype == SubtypeToolUse && msg.ToolID != "" {
+			toolNames[msg.ToolID] = msg.ToolName
+		}
+	}
+
 	var urls []string
 	for _, msg := range messages {
 		blocks := ExtractToolResults(msg)
 		for _, block := range blocks {
+			// Only extract PR URLs from Bash tool results.
+			if block.ToolUseID != "" {
+				toolName := toolNames[block.ToolUseID]
+				if !isBashTool(toolName) {
+					continue
+				}
+			}
 			found := extractPRURLs(block.Content)
 			urls = appendUnique(urls, found...)
 		}

--- a/pkg/claude/persistent.go
+++ b/pkg/claude/persistent.go
@@ -36,6 +36,7 @@ type PersistentProcess struct {
 	toolCalls     map[string]int
 	modelUsage    map[string]int
 	prURLs        []string
+	toolUseIDs    map[string]string // toolUseID -> toolName
 	errorCount    int
 	tokenUsage    TokenUsage
 	lastMessage   string
@@ -84,6 +85,7 @@ func NewPersistentProcess(opts Options) *PersistentProcess {
 		opts:        opts,
 		status:      ProcessStatusIdle,
 		subagents:   newSubagentTracker(),
+		toolUseIDs:  make(map[string]string),
 		done:        done,
 		processDone: processDone,
 		autoRestart: true,
@@ -290,6 +292,9 @@ func (p *PersistentProcess) readLoop(ctx context.Context, stdout io.ReadCloser, 
 				p.toolCallCount++
 				p.lastToolName = msg.ToolName
 				p.toolCalls[msg.ToolName]++
+				if msg.ToolID != "" {
+					p.toolUseIDs[msg.ToolID] = msg.ToolName
+				}
 				p.subagents.handleToolUse(msg)
 			} else {
 				p.subagents.handleMessage(msg)
@@ -300,7 +305,11 @@ func (p *PersistentProcess) readLoop(ctx context.Context, stdout io.ReadCloser, 
 		// Extract PR URLs and count errors from tool_result content blocks.
 		if blocks := ExtractToolResults(msg); len(blocks) > 0 {
 			for _, block := range blocks {
-				p.prURLs = appendUnique(p.prURLs, extractPRURLs(block.Content)...)
+				// Only extract PR URLs from Bash tool results to avoid
+				// false positives from file content (Read, Write, etc.).
+				if block.ToolUseID == "" || isBashTool(p.toolUseIDs[block.ToolUseID]) {
+					p.prURLs = appendUnique(p.prURLs, extractPRURLs(block.Content)...)
+				}
 				if block.IsError {
 					p.errorCount++
 				}
@@ -431,6 +440,7 @@ func (p *PersistentProcess) RunWithOptions(ctx context.Context, prompt string, r
 	p.toolCalls = make(map[string]int)
 	p.modelUsage = make(map[string]int)
 	p.prURLs = nil
+	p.toolUseIDs = make(map[string]string)
 	p.errorCount = 0
 	p.tokenUsage = TokenUsage{}
 	p.totalCost = 0

--- a/pkg/claude/process.go
+++ b/pkg/claude/process.go
@@ -86,6 +86,7 @@ type Process struct {
 	toolCalls     map[string]int
 	modelUsage    map[string]int
 	prURLs        []string
+	toolUseIDs    map[string]string // toolUseID -> toolName
 	errorCount    int
 	tokenUsage    TokenUsage
 	lastMessage   string
@@ -171,6 +172,7 @@ func (p *Process) RunWithOptions(ctx context.Context, prompt string, runOpts *Ru
 	p.toolCalls = make(map[string]int)
 	p.modelUsage = make(map[string]int)
 	p.prURLs = nil
+	p.toolUseIDs = make(map[string]string)
 	p.errorCount = 0
 	p.tokenUsage = TokenUsage{}
 	p.totalCost = 0
@@ -299,6 +301,9 @@ func (p *Process) RunWithOptions(ctx context.Context, prompt string, runOpts *Ru
 					p.toolCallCount++
 					p.lastToolName = msg.ToolName
 					p.toolCalls[msg.ToolName]++
+					if msg.ToolID != "" {
+						p.toolUseIDs[msg.ToolID] = msg.ToolName
+					}
 					p.subagents.handleToolUse(msg)
 				} else {
 					p.subagents.handleMessage(msg)
@@ -309,7 +314,11 @@ func (p *Process) RunWithOptions(ctx context.Context, prompt string, runOpts *Ru
 			// Extract PR URLs and count errors from tool_result content blocks.
 			if blocks := ExtractToolResults(msg); len(blocks) > 0 {
 				for _, block := range blocks {
-					p.prURLs = appendUnique(p.prURLs, extractPRURLs(block.Content)...)
+					// Only extract PR URLs from Bash tool results to avoid
+					// false positives from file content (Read, Write, etc.).
+					if block.ToolUseID == "" || isBashTool(p.toolUseIDs[block.ToolUseID]) {
+						p.prURLs = appendUnique(p.prURLs, extractPRURLs(block.Content)...)
+					}
 					if block.IsError {
 						p.errorCount++
 					}


### PR DESCRIPTION
## Summary

- fix: filter PR URL extraction to Bash tool results only (#123)

## Related issues

Relates to #123

## Commits

### fix: filter PR URL extraction to Bash tool results only (#123)

PR URLs embedded in file content (test fixtures, docs) read by non-Bash
tools were being falsely reported as real PR URLs. This change tracks the
tool_use_id-to-tool_name mapping during streaming and only extracts PR
URLs from Bash/shell tool results, preventing false positives from Read,
Write, and other file-content tools.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

