### PR TITLE
Feat: support KLAUS_SOUL_FILE env var for configurable personality path

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -266,15 +266,20 @@ func runServe(portFlag string, cfg config.Config, enableOAuth bool, oauthConfig 
 		opts.NoSessionPersistence = true
 	}
 
-	// Load personality SOUL.md if mounted by klausctl.
-	if soul, err := loadSOULFile(defaultSOULPath); err != nil {
-		log.Printf("WARNING: failed to load personality from %s: %v", defaultSOULPath, err)
+	// Load personality SOUL.md. The KLAUS_SOUL_FILE env var allows operators
+	// to override the default path (useful for Kubernetes image volumes where
+	// SubPath is not supported).
+	soulPath := soulFilePath()
+	if soul, err := loadSOULFile(soulPath); err != nil {
+		log.Printf("WARNING: failed to load personality from %q: %v", soulPath, err)
 	} else if soul != "" {
 		if opts.AppendSystemPrompt != "" {
 			opts.AppendSystemPrompt += "\n\n"
 		}
 		opts.AppendSystemPrompt += soul
-		log.Printf("Loaded personality from %s (%d bytes)", defaultSOULPath, len(soul))
+		log.Printf("Loaded personality from %q (%d bytes)", soulPath, len(soul))
+	} else if os.Getenv("KLAUS_SOUL_FILE") != "" {
+		log.Printf("WARNING: KLAUS_SOUL_FILE is set to %q but the file does not exist or is empty", soulPath)
 	}
 
 	// Create the Claude process manager.
@@ -476,6 +481,16 @@ func applyOAuthFlagOverrides(
 	if cmd.Flags().Changed("tls-key-file") {
 		cfg.OAuth.TLS.KeyFile = tlsKey
 	}
+}
+
+// soulFilePath returns the path to the SOUL.md personality file.
+// If the KLAUS_SOUL_FILE environment variable is set, its value is used;
+// otherwise defaultSOULPath is returned.
+func soulFilePath() string {
+	if p := os.Getenv("KLAUS_SOUL_FILE"); p != "" {
+		return p
+	}
+	return defaultSOULPath
 }
 
 // loadSOULFile reads a SOUL.md personality file and returns its content

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -163,4 +163,32 @@ func TestLoadSOULFile_ExactlyMaxSize(t *testing.T) {
 	}
 }
 
+func TestSoulFilePath_Unset(t *testing.T) {
+	// Ensure the env var is saved/restored, then unset it.
+	t.Setenv("KLAUS_SOUL_FILE", "")
+	os.Unsetenv("KLAUS_SOUL_FILE")
+
+	got := soulFilePath()
+	if got != defaultSOULPath {
+		t.Errorf("expected default path %q, got %q", defaultSOULPath, got)
+	}
+}
+
+func TestSoulFilePath_EmptyString(t *testing.T) {
+	t.Setenv("KLAUS_SOUL_FILE", "")
+	got := soulFilePath()
+	if got != defaultSOULPath {
+		t.Errorf("expected default path %q when env is empty string, got %q", defaultSOULPath, got)
+	}
+}
+
+func TestSoulFilePath_EnvOverride(t *testing.T) {
+	custom := "/var/lib/klaus/personality/SOUL.md"
+	t.Setenv("KLAUS_SOUL_FILE", custom)
+	got := soulFilePath()
+	if got != custom {
+		t.Errorf("expected %q, got %q", custom, got)
+	}
+}
+
 // TestParseBool has moved to pkg/config/config_test.go alongside the config loader.


### PR DESCRIPTION
## Summary

- feat: support KLAUS_SOUL_FILE env var for configurable personality path

## Related issues

Relates to #126
Relates to #134894

## Commits

### feat: support KLAUS_SOUL_FILE env var for configurable personality path

Kubernetes image volumes do not support SubPath mounts
(kubernetes/kubernetes#134894), so operators cannot mount the personality
file at the hardcoded /etc/klaus/SOUL.md path. The KLAUS_SOUL_FILE
environment variable lets them point to an alternative location such as
/var/lib/klaus/personality/SOUL.md.

When the env var is unset or empty the existing default path is used,
keeping klausctl behaviour unchanged. A warning is logged when the env
var is set but the target file is missing or empty, making
misconfigurations visible.

Closes #126

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

