### PR TITLE
fix: harden ResultStore path resolution and remove dead parameter

### DIFF
--- a/pkg/claude/resultstore.go
+++ b/pkg/claude/resultstore.go
@@ -87,20 +87,19 @@ func NewResultStore(dir string) *ResultStore {
 	return &ResultStore{dir: dir}
 }
 
-// ResultStorePath returns the result store directory. It resolves the path
-// using the following precedence:
-//  1. The explicitly provided resultDir (from Options.ResultDir)
-//  2. The KLAUS_RESULT_DIR environment variable
-//  3. $HOME/.klaus/results/ (default, outside any workspace)
+// ResultStorePath returns the default result store directory based on the
+// environment. It checks (in order):
+//  1. The KLAUS_RESULT_DIR environment variable (must be absolute)
+//  2. $HOME/.klaus/results/
+//  3. A UID-scoped directory under os.TempDir() as a last resort
 //
-// The workDir parameter is no longer used but is kept for backward
-// compatibility of the function signature.
-func ResultStorePath(workDir string) string {
-	return resultStorePath(workDir, os.Getenv, os.UserHomeDir)
+// Note: Options.ResultDir is handled by resultStoreDir, not this function.
+func ResultStorePath() string {
+	return resultStorePath(os.Getenv, os.UserHomeDir)
 }
 
 // resultStorePath is the testable inner implementation of ResultStorePath.
-func resultStorePath(_ string, getenv func(string) string, homeDir func() (string, error)) string {
+func resultStorePath(getenv func(string) string, homeDir func() (string, error)) string {
 	if dir := getenv(resultDirEnvVar); dir != "" {
 		dir = filepath.Clean(dir)
 		if filepath.IsAbs(dir) {
@@ -127,7 +126,7 @@ func resultStoreDir(opts Options) string {
 		}
 		log.Printf("[klaus] WARNING: ResultDir %q is not an absolute path, falling back to default", opts.ResultDir)
 	}
-	return ResultStorePath(opts.WorkDir)
+	return ResultStorePath()
 }
 
 // Save persists a result to disk. It creates the directory if needed.

--- a/pkg/claude/resultstore_test.go
+++ b/pkg/claude/resultstore_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -225,7 +226,7 @@ func TestPersistedResult_ToResultDetailInfo(t *testing.T) {
 
 func TestResultStorePath_EnvVar(t *testing.T) {
 	t.Setenv("KLAUS_RESULT_DIR", "/custom/result/dir")
-	got := ResultStorePath("/workspace")
+	got := ResultStorePath()
 	if got != "/custom/result/dir" {
 		t.Errorf("ResultStorePath with env = %q, want %q", got, "/custom/result/dir")
 	}
@@ -235,13 +236,13 @@ func TestResultStorePath_DefaultHome(t *testing.T) {
 	// Ensure the env var is unset so the home-based default is used.
 	t.Setenv("KLAUS_RESULT_DIR", "")
 
-	got := ResultStorePath("/workspace")
-	// The result should be under $HOME/.klaus/results/, not inside /workspace.
-	if got == "/workspace/.klaus" {
-		t.Errorf("ResultStorePath should NOT return workspace-relative path, got %q", got)
-	}
+	got := ResultStorePath()
+	// The result should be under $HOME/.klaus/results/, not inside a workspace.
 	if !filepath.IsAbs(got) {
 		t.Errorf("ResultStorePath should return an absolute path, got %q", got)
+	}
+	if !strings.HasSuffix(got, ".klaus/results") && !strings.Contains(got, "klaus-results") {
+		t.Errorf("ResultStorePath should contain klaus result dir, got %q", got)
 	}
 }
 
@@ -253,8 +254,13 @@ func Test_resultStorePath(t *testing.T) {
 		want    string
 	}{
 		{
-			name:    "env var takes precedence",
-			getenv:  func(k string) string { return "/env/result/dir" },
+			name: "env var takes precedence",
+			getenv: func(k string) string {
+				if k == "KLAUS_RESULT_DIR" {
+					return "/env/result/dir"
+				}
+				return ""
+			},
 			homeDir: func() (string, error) { return "/home/user", nil },
 			want:    "/env/result/dir",
 		},
@@ -286,7 +292,7 @@ func Test_resultStorePath(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := resultStorePath("", tt.getenv, tt.homeDir)
+			got := resultStorePath(tt.getenv, tt.homeDir)
 			if got != tt.want {
 				t.Errorf("resultStorePath() = %q, want %q", got, tt.want)
 			}
@@ -309,7 +315,7 @@ func Test_resultStoreDir(t *testing.T) {
 	t.Run("falls back to ResultStorePath when ResultDir empty", func(t *testing.T) {
 		opts := Options{WorkDir: "/workspace"}
 		got := resultStoreDir(opts)
-		expected := ResultStorePath("/workspace")
+		expected := ResultStorePath()
 		if got != expected {
 			t.Errorf("resultStoreDir() = %q, want %q", got, expected)
 		}
@@ -321,7 +327,7 @@ func Test_resultStoreDir(t *testing.T) {
 			ResultDir: "relative/path",
 		}
 		got := resultStoreDir(opts)
-		expected := ResultStorePath("/workspace")
+		expected := ResultStorePath()
 		if got != expected {
 			t.Errorf("resultStoreDir() with relative path = %q, want fallback %q", got, expected)
 		}


### PR DESCRIPTION
## Summary

Follow-up to PR #137 (issue #136). Addresses security audit and code review findings:

- **Path validation**: Reject relative paths in `KLAUS_RESULT_DIR` env var and `Options.ResultDir` to prevent writing to unintended locations
- **Path sanitization**: Apply `filepath.Clean` to sanitize traversal components
- **Tmp fallback hardening**: Include UID in `/tmp` fallback directory name to prevent directory pre-creation attacks
- **API cleanup**: Remove dead `workDir` parameter from `ResultStorePath()` since the result store is no longer workspace-relative
- **Test improvements**: Tighten mocks, add relative-path rejection tests, stronger assertions

Relates to #136


Made with [Cursor](https://cursor.com)