### PR TITLE
fix: prevent data race in Messages() slice copying

### DIFF
--- a/pkg/claude/persistent.go
+++ b/pkg/claude/persistent.go
@@ -704,29 +704,29 @@ func (p *PersistentProcess) ResultDetail() ResultDetailInfo {
 func (p *PersistentProcess) Messages() MessagesInfo {
 	p.mu.RLock()
 	status := p.status
-	live := p.liveMessages
-	res := p.result
+	live := copyStreamMessages(p.liveMessages)
+	resMessages := copyStreamMessages(p.result.messages)
 	store := p.resultStore
 	p.mu.RUnlock()
 
 	if status == ProcessStatusBusy || status == ProcessStatusStarting {
 		return MessagesInfo{
 			Status:   status,
-			Messages: SummarizeMessages(copyStreamMessages(live)),
+			Messages: SummarizeMessages(live),
 		}
 	}
 
-	if len(res.messages) > 0 {
+	if len(resMessages) > 0 {
 		return MessagesInfo{
 			Status:   status,
-			Messages: SummarizeMessages(res.messages),
+			Messages: SummarizeMessages(resMessages),
 		}
 	}
 
 	if len(live) > 0 {
 		return MessagesInfo{
 			Status:   status,
-			Messages: SummarizeMessages(copyStreamMessages(live)),
+			Messages: SummarizeMessages(live),
 		}
 	}
 

--- a/pkg/claude/process.go
+++ b/pkg/claude/process.go
@@ -591,8 +591,8 @@ func (p *Process) ResultDetail() ResultDetailInfo {
 func (p *Process) Messages() MessagesInfo {
 	p.mu.RLock()
 	status := p.status
-	live := p.liveMessages
-	res := p.result
+	live := copyStreamMessages(p.liveMessages)
+	resMessages := copyStreamMessages(p.result.messages)
 	store := p.resultStore
 	p.mu.RUnlock()
 
@@ -600,15 +600,15 @@ func (p *Process) Messages() MessagesInfo {
 	if status == ProcessStatusBusy || status == ProcessStatusStarting {
 		return MessagesInfo{
 			Status:   status,
-			Messages: SummarizeMessages(copyStreamMessages(live)),
+			Messages: SummarizeMessages(live),
 		}
 	}
 
 	// When completed, prefer in-memory result messages.
-	if len(res.messages) > 0 {
+	if len(resMessages) > 0 {
 		return MessagesInfo{
 			Status:   status,
-			Messages: SummarizeMessages(res.messages),
+			Messages: SummarizeMessages(resMessages),
 		}
 	}
 
@@ -616,7 +616,7 @@ func (p *Process) Messages() MessagesInfo {
 	if len(live) > 0 {
 		return MessagesInfo{
 			Status:   status,
-			Messages: SummarizeMessages(copyStreamMessages(live)),
+			Messages: SummarizeMessages(live),
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Fix data race in `Messages()` on both `Process` and `PersistentProcess` where `result.messages` slice was read after releasing the mutex, sharing its backing array with the internal state that `submitDrain` could concurrently overwrite.
- Copy both `liveMessages` and `result.messages` under the read lock before releasing it, matching the defensive copy pattern used throughout the codebase.

## Approach

The `Messages()` method previously copied the `resultState` struct by value under `RLock`, but Go slice copies only copy the header (pointer, length, capacity), not the backing array. After `RUnlock`, the `submitDrain` goroutine could call `setResult()` which replaces `p.result.messages`, creating a data race if `SummarizeMessages` was still iterating the shared backing array.

The fix calls `copyStreamMessages()` for both slice fields while still holding the lock, ensuring the returned data is fully independent of internal state.

## Issue reference

Relates to #140

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] `base:code-reviewer` identified the race condition
- [x] Verified the fix follows the same copy-under-lock pattern as `Status()` and `ResultDetail()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)