### PR TITLE
feat: return raw stream-json from messages MCP tool

### DIFF
--- a/pkg/claude/message.go
+++ b/pkg/claude/message.go
@@ -212,6 +212,15 @@ type MessagesInfo struct {
 	Messages []MessageSummary `json:"messages"`
 }
 
+// RawMessagesInfo holds raw stream-json messages along with the process
+// status and total message count. Used by the messages MCP tool to return
+// lossless message data for external consumers.
+type RawMessagesInfo struct {
+	Status   ProcessStatus     `json:"status"`
+	Total    int               `json:"total"`
+	Messages []json.RawMessage `json:"messages"`
+}
+
 // MessageSummary is a simplified representation of a StreamMessage
 // with only role and content, suitable for external consumers.
 type MessageSummary struct {
@@ -231,6 +240,46 @@ func SummarizeMessages(msgs []StreamMessage) []MessageSummary {
 		summaries = append(summaries, s)
 	}
 	return summaries
+}
+
+// collectRawMessages builds a RawMessagesInfo from a slice of StreamMessages,
+// applying offset and type filtering. Total always reflects the unfiltered
+// count so callers can detect whether more messages exist.
+func collectRawMessages(status ProcessStatus, msgs []StreamMessage, offset int, types []string) RawMessagesInfo {
+	total := len(msgs)
+
+	// Build type filter set.
+	var typeSet map[string]bool
+	if len(types) > 0 {
+		typeSet = make(map[string]bool, len(types))
+		for _, t := range types {
+			typeSet[t] = true
+		}
+	}
+
+	// Apply offset.
+	if offset >= len(msgs) {
+		return RawMessagesInfo{Status: status, Total: total, Messages: []json.RawMessage{}}
+	}
+	if offset > 0 {
+		msgs = msgs[offset:]
+	}
+
+	raw := make([]json.RawMessage, 0, len(msgs))
+	for _, msg := range msgs {
+		if typeSet != nil && !typeSet[string(msg.Type)] {
+			continue
+		}
+		if len(msg.Raw) > 0 {
+			raw = append(raw, msg.Raw)
+		}
+	}
+
+	return RawMessagesInfo{
+		Status:   status,
+		Total:    total,
+		Messages: raw,
+	}
 }
 
 // summarizeMessage converts a single StreamMessage to a MessageSummary.

--- a/pkg/claude/persistent.go
+++ b/pkg/claude/persistent.go
@@ -742,6 +742,39 @@ func (p *PersistentProcess) Messages() MessagesInfo {
 	return MessagesInfo{Status: status}
 }
 
+// RawMessages returns the raw stream-json messages from the current or last
+// completed run. offset skips the first N messages; types filters by message
+// type (empty means all types). The Total field always reflects the full
+// unfiltered message count.
+func (p *PersistentProcess) RawMessages(offset int, types []string) RawMessagesInfo {
+	p.mu.RLock()
+	status := p.status
+	live := copyStreamMessages(p.liveMessages)
+	resMessages := copyStreamMessages(p.result.messages)
+	store := p.resultStore
+	p.mu.RUnlock()
+
+	if status == ProcessStatusBusy || status == ProcessStatusStarting {
+		return collectRawMessages(status, live, offset, types)
+	}
+
+	if len(resMessages) > 0 {
+		return collectRawMessages(status, resMessages, offset, types)
+	}
+
+	if len(live) > 0 {
+		return collectRawMessages(status, live, offset, types)
+	}
+
+	if store != nil {
+		if pr, err := store.Load(); err == nil && pr != nil && len(pr.Messages) > 0 {
+			return collectRawMessages(status, pr.Messages, offset, types)
+		}
+	}
+
+	return RawMessagesInfo{Status: status, Messages: []json.RawMessage{}}
+}
+
 // Done returns a channel closed when the current prompt response is complete.
 func (p *PersistentProcess) Done() <-chan struct{} {
 	p.mu.RLock()

--- a/pkg/claude/process.go
+++ b/pkg/claude/process.go
@@ -633,6 +633,43 @@ func (p *Process) Messages() MessagesInfo {
 	return MessagesInfo{Status: status}
 }
 
+// RawMessages returns the raw stream-json messages from the current or last
+// completed run. offset skips the first N messages; types filters by message
+// type (empty means all types). The Total field always reflects the full
+// unfiltered message count.
+func (p *Process) RawMessages(offset int, types []string) RawMessagesInfo {
+	p.mu.RLock()
+	status := p.status
+	live := copyStreamMessages(p.liveMessages)
+	resMessages := copyStreamMessages(p.result.messages)
+	store := p.resultStore
+	p.mu.RUnlock()
+
+	// While busy or starting, return live messages.
+	if status == ProcessStatusBusy || status == ProcessStatusStarting {
+		return collectRawMessages(status, live, offset, types)
+	}
+
+	// When completed, prefer in-memory result messages.
+	if len(resMessages) > 0 {
+		return collectRawMessages(status, resMessages, offset, types)
+	}
+
+	// If live messages are available (e.g. just finished), use those.
+	if len(live) > 0 {
+		return collectRawMessages(status, live, offset, types)
+	}
+
+	// Fall back to persisted result on disk.
+	if store != nil {
+		if pr, err := store.Load(); err == nil && pr != nil && len(pr.Messages) > 0 {
+			return collectRawMessages(status, pr.Messages, offset, types)
+		}
+	}
+
+	return RawMessagesInfo{Status: status, Messages: []json.RawMessage{}}
+}
+
 // Done returns a channel closed when the current run completes.
 func (p *Process) Done() <-chan struct{} {
 	p.mu.RLock()

--- a/pkg/claude/process_test.go
+++ b/pkg/claude/process_test.go
@@ -2,6 +2,7 @@ package claude
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 )
 
@@ -487,6 +488,196 @@ func TestSummarizeMessages(t *testing.T) {
 	}
 	if summaries[3].Role != "result" || summaries[3].Content != "done" {
 		t.Errorf("unexpected summary[3]: %+v", summaries[3])
+	}
+}
+
+func TestProcess_RawMessages_Idle(t *testing.T) {
+	process := NewProcess(DefaultOptions())
+
+	info := process.RawMessages(0, nil)
+	if info.Status != ProcessStatusIdle {
+		t.Errorf("expected status %q, got %q", ProcessStatusIdle, info.Status)
+	}
+	if info.Total != 0 {
+		t.Errorf("expected total 0, got %d", info.Total)
+	}
+	if len(info.Messages) != 0 {
+		t.Errorf("expected 0 messages, got %d", len(info.Messages))
+	}
+}
+
+func TestProcess_RawMessages_Busy(t *testing.T) {
+	process := NewProcess(DefaultOptions())
+
+	raw0 := json.RawMessage(`{"type":"system","session_id":"sess-1"}`)
+	raw1 := json.RawMessage(`{"type":"assistant","subtype":"text","text":"thinking..."}`)
+	raw2 := json.RawMessage(`{"type":"assistant","subtype":"tool_use","tool_name":"Bash"}`)
+
+	process.mu.Lock()
+	process.status = ProcessStatusBusy
+	process.liveMessages = []StreamMessage{
+		{Type: MessageTypeSystem, SessionID: "sess-1", Raw: raw0},
+		{Type: MessageTypeAssistant, Subtype: SubtypeText, Text: "thinking...", Raw: raw1},
+		{Type: MessageTypeAssistant, Subtype: SubtypeToolUse, ToolName: "Bash", Raw: raw2},
+	}
+	process.mu.Unlock()
+
+	info := process.RawMessages(0, nil)
+	if info.Status != ProcessStatusBusy {
+		t.Errorf("expected status %q, got %q", ProcessStatusBusy, info.Status)
+	}
+	if info.Total != 3 {
+		t.Errorf("expected total 3, got %d", info.Total)
+	}
+	if len(info.Messages) != 3 {
+		t.Fatalf("expected 3 messages, got %d", len(info.Messages))
+	}
+	if string(info.Messages[0]) != string(raw0) {
+		t.Errorf("expected raw message %s, got %s", raw0, info.Messages[0])
+	}
+}
+
+func TestProcess_RawMessages_WithOffset(t *testing.T) {
+	process := NewProcess(DefaultOptions())
+
+	raw0 := json.RawMessage(`{"type":"system","session_id":"sess-1"}`)
+	raw1 := json.RawMessage(`{"type":"assistant","subtype":"text","text":"hello"}`)
+	raw2 := json.RawMessage(`{"type":"result","result":"done"}`)
+
+	process.mu.Lock()
+	process.status = ProcessStatusBusy
+	process.liveMessages = []StreamMessage{
+		{Type: MessageTypeSystem, Raw: raw0},
+		{Type: MessageTypeAssistant, Subtype: SubtypeText, Raw: raw1},
+		{Type: MessageTypeResult, Raw: raw2},
+	}
+	process.mu.Unlock()
+
+	info := process.RawMessages(2, nil)
+	if info.Total != 3 {
+		t.Errorf("expected total 3, got %d", info.Total)
+	}
+	if len(info.Messages) != 1 {
+		t.Fatalf("expected 1 message after offset 2, got %d", len(info.Messages))
+	}
+	if string(info.Messages[0]) != string(raw2) {
+		t.Errorf("expected last raw message, got %s", info.Messages[0])
+	}
+}
+
+func TestProcess_RawMessages_WithTypeFilter(t *testing.T) {
+	process := NewProcess(DefaultOptions())
+
+	raw0 := json.RawMessage(`{"type":"system","session_id":"sess-1"}`)
+	raw1 := json.RawMessage(`{"type":"assistant","subtype":"text","text":"hello"}`)
+	raw2 := json.RawMessage(`{"type":"user","message":{"content":[{"type":"tool_result"}]}}`)
+	raw3 := json.RawMessage(`{"type":"result","result":"done"}`)
+
+	process.mu.Lock()
+	process.status = ProcessStatusBusy
+	process.liveMessages = []StreamMessage{
+		{Type: MessageTypeSystem, Raw: raw0},
+		{Type: MessageTypeAssistant, Subtype: SubtypeText, Raw: raw1},
+		{Type: "user", Raw: raw2},
+		{Type: MessageTypeResult, Raw: raw3},
+	}
+	process.mu.Unlock()
+
+	info := process.RawMessages(0, []string{"assistant", "result"})
+	if info.Total != 4 {
+		t.Errorf("expected total 4 (unfiltered), got %d", info.Total)
+	}
+	if len(info.Messages) != 2 {
+		t.Fatalf("expected 2 filtered messages, got %d", len(info.Messages))
+	}
+	if string(info.Messages[0]) != string(raw1) {
+		t.Errorf("expected assistant message, got %s", info.Messages[0])
+	}
+	if string(info.Messages[1]) != string(raw3) {
+		t.Errorf("expected result message, got %s", info.Messages[1])
+	}
+}
+
+func TestProcess_RawMessages_OffsetBeyondTotal(t *testing.T) {
+	process := NewProcess(DefaultOptions())
+
+	process.mu.Lock()
+	process.status = ProcessStatusBusy
+	process.liveMessages = []StreamMessage{
+		{Type: MessageTypeSystem, Raw: json.RawMessage(`{"type":"system"}`)},
+	}
+	process.mu.Unlock()
+
+	info := process.RawMessages(10, nil)
+	if info.Total != 1 {
+		t.Errorf("expected total 1, got %d", info.Total)
+	}
+	if len(info.Messages) != 0 {
+		t.Errorf("expected 0 messages when offset > total, got %d", len(info.Messages))
+	}
+	// Messages should be an empty slice (not nil) to serialize as [] in JSON.
+	if info.Messages == nil {
+		t.Error("expected non-nil empty Messages slice, got nil")
+	}
+}
+
+func TestProcess_RawMessages_OffsetAndTypeFilter(t *testing.T) {
+	process := NewProcess(DefaultOptions())
+
+	raws := make([]json.RawMessage, 5)
+	msgs := make([]StreamMessage, 5)
+	for i := range raws {
+		typ := MessageTypeAssistant
+		if i%2 == 0 {
+			typ = MessageTypeSystem
+		}
+		raws[i] = json.RawMessage(fmt.Sprintf(`{"type":"%s","idx":%d}`, typ, i))
+		msgs[i] = StreamMessage{Type: typ, Raw: raws[i]}
+	}
+
+	process.mu.Lock()
+	process.status = ProcessStatusBusy
+	process.liveMessages = msgs
+	process.mu.Unlock()
+
+	// Offset 2 skips msgs[0] and msgs[1], leaving msgs[2](system), msgs[3](assistant), msgs[4](system)
+	// Filter to "system" only: msgs[2] and msgs[4]
+	info := process.RawMessages(2, []string{"system"})
+	if info.Total != 5 {
+		t.Errorf("expected total 5, got %d", info.Total)
+	}
+	if len(info.Messages) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(info.Messages))
+	}
+}
+
+func TestProcess_RawMessages_Completed(t *testing.T) {
+	process := NewProcess(DefaultOptions())
+
+	raw0 := json.RawMessage(`{"type":"system","session_id":"sess-1"}`)
+	raw1 := json.RawMessage(`{"type":"result","result":"final answer"}`)
+
+	process.mu.Lock()
+	process.status = ProcessStatusCompleted
+	process.result = resultState{
+		text:      "done",
+		completed: true,
+		messages: []StreamMessage{
+			{Type: MessageTypeSystem, SessionID: "sess-1", Raw: raw0},
+			{Type: MessageTypeResult, Result: "final answer", Raw: raw1},
+		},
+	}
+	process.mu.Unlock()
+
+	info := process.RawMessages(0, nil)
+	if info.Status != ProcessStatusCompleted {
+		t.Errorf("expected status %q, got %q", ProcessStatusCompleted, info.Status)
+	}
+	if info.Total != 2 {
+		t.Errorf("expected total 2, got %d", info.Total)
+	}
+	if len(info.Messages) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(info.Messages))
 	}
 }
 

--- a/pkg/claude/prompter.go
+++ b/pkg/claude/prompter.go
@@ -48,6 +48,12 @@ type Prompter interface {
 	// it falls back to the stored result messages or persisted state.
 	Messages() MessagesInfo
 
+	// RawMessages returns the raw stream-json messages from the current or
+	// last completed run. Unlike Messages(), it preserves the original JSON
+	// bytes without lossy summarization. offset skips the first N messages;
+	// types filters by message type (empty means all types).
+	RawMessages(offset int, types []string) RawMessagesInfo
+
 	// MarshalStatus returns the status as JSON.
 	MarshalStatus() ([]byte, error)
 }

--- a/pkg/mcp/tools.go
+++ b/pkg/mcp/tools.go
@@ -14,6 +14,14 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 )
 
+// validMessageTypes is the set of accepted values for the types filter parameter.
+var validMessageTypes = map[string]bool{
+	"system":    true,
+	"assistant": true,
+	"user":      true,
+	"result":    true,
+}
+
 // RegisterTools registers all MCP tools on the given server. The serverCtx
 // controls the lifetime of background drain goroutines spawned by non-blocking
 // prompt submissions; it should be cancelled during server shutdown to ensure
@@ -355,13 +363,50 @@ func resultTool(process claudepkg.Prompter) server.ServerTool {
 
 func messagesTool(process claudepkg.Prompter) server.ServerTool {
 	tool := mcp.NewTool("messages",
-		mcp.WithDescription("Get the conversation messages from the current or last completed run. "+
+		mcp.WithDescription("Get the raw stream-json conversation messages from the current or last completed run. "+
 			"Returns messages in real time while the agent is busy, or from the last completed run otherwise. "+
-			"Each message has a role (system/assistant/result) and content."),
+			"Each message is the original JSON object from the Claude CLI stream-json protocol. "+
+			"The total field reports the full unfiltered message count (useful with offset to detect new messages)."),
+		mcp.WithNumber("offset",
+			mcp.Description("Skip the first N messages and return from N onward. "+
+				"Enables efficient follow mode: set offset to the previous total to fetch only new messages. Default: 0."),
+		),
+		mcp.WithString("types",
+			mcp.Description("Comma-separated list of message types to include (e.g. \"assistant,result\"). "+
+				"Valid types: system, assistant, user, result. Default: all types."),
+		),
 	)
 
-	handler := func(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		info := process.Messages()
+	handler := func(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		offset, err := optionalFloat(request, "offset")
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		if offset < 0 || offset != float64(int(offset)) {
+			return mcp.NewToolResultError("parameter \"offset\" must be a non-negative integer"), nil
+		}
+
+		typesStr, err := optionalString(request, "types")
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		var types []string
+		if typesStr != "" {
+			for _, t := range strings.Split(typesStr, ",") {
+				t = strings.TrimSpace(t)
+				if t == "" {
+					continue
+				}
+				if !validMessageTypes[t] {
+					return mcp.NewToolResultError(
+						fmt.Sprintf("invalid message type %q; valid types: system, assistant, user, result", t)), nil
+				}
+				types = append(types, t)
+			}
+		}
+
+		info := process.RawMessages(int(offset), types)
 		data, err := json.Marshal(info)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("failed to marshal messages: %v", err)), nil

--- a/pkg/mcp/tools_test.go
+++ b/pkg/mcp/tools_test.go
@@ -31,6 +31,11 @@ type mockPrompter struct {
 	resultDetail claudepkg.ResultDetailInfo
 	// messagesInfo is returned by Messages.
 	messagesInfo claudepkg.MessagesInfo
+	// rawMessagesInfo is returned by RawMessages.
+	rawMessagesInfo claudepkg.RawMessagesInfo
+	// lastRawOffset and lastRawTypes track the last RawMessages call args.
+	lastRawOffset int
+	lastRawTypes  []string
 }
 
 func (m *mockPrompter) Run(ctx context.Context, prompt string) (<-chan claudepkg.StreamMessage, error) {
@@ -105,6 +110,12 @@ func (m *mockPrompter) Done() <-chan struct{} {
 }
 
 func (m *mockPrompter) Messages() claudepkg.MessagesInfo { return m.messagesInfo }
+
+func (m *mockPrompter) RawMessages(offset int, types []string) claudepkg.RawMessagesInfo {
+	m.lastRawOffset = offset
+	m.lastRawTypes = types
+	return m.rawMessagesInfo
+}
 
 func (m *mockPrompter) MarshalStatus() ([]byte, error) {
 	return json.Marshal(m.status)
@@ -826,13 +837,16 @@ func TestStopTool(t *testing.T) {
 // --- Messages tool tests ---
 
 func TestMessagesTool_WithMessages(t *testing.T) {
+	raw0 := json.RawMessage(`{"type":"system","session_id":"sess-001"}`)
+	raw1 := json.RawMessage(`{"type":"assistant","subtype":"text","text":"Working on it..."}`)
+	raw2 := json.RawMessage(`{"type":"assistant","subtype":"tool_use","tool_name":"Bash"}`)
+
 	mock := &mockPrompter{
-		messagesInfo: claudepkg.MessagesInfo{
+		rawMessagesInfo: claudepkg.RawMessagesInfo{
 			Status: claudepkg.ProcessStatusBusy,
-			Messages: []claudepkg.MessageSummary{
-				{Role: "system", Content: "Session: sess-001"},
-				{Role: "assistant", Content: "Working on it..."},
-				{Role: "assistant", Content: "Using tool: Bash"},
+			Total:  3,
+			Messages: []json.RawMessage{
+				raw0, raw1, raw2,
 			},
 		},
 	}
@@ -849,7 +863,7 @@ func TestMessagesTool_WithMessages(t *testing.T) {
 	}
 
 	text := extractText(t, result)
-	var info claudepkg.MessagesInfo
+	var info claudepkg.RawMessagesInfo
 	if err := json.Unmarshal([]byte(text), &info); err != nil {
 		t.Fatalf("failed to parse messages JSON: %v (text: %s)", err, text)
 	}
@@ -857,23 +871,29 @@ func TestMessagesTool_WithMessages(t *testing.T) {
 	if info.Status != claudepkg.ProcessStatusBusy {
 		t.Errorf("expected status %q, got %q", claudepkg.ProcessStatusBusy, info.Status)
 	}
+	if info.Total != 3 {
+		t.Errorf("expected total 3, got %d", info.Total)
+	}
 	if len(info.Messages) != 3 {
 		t.Fatalf("expected 3 messages, got %d", len(info.Messages))
 	}
-	if info.Messages[0].Role != "system" {
-		t.Errorf("expected first message role %q, got %q", "system", info.Messages[0].Role)
+
+	// Verify raw messages are preserved as JSON objects.
+	var first map[string]any
+	if err := json.Unmarshal(info.Messages[0], &first); err != nil {
+		t.Fatalf("failed to parse first message: %v", err)
 	}
-	if info.Messages[1].Content != "Working on it..." {
-		t.Errorf("expected second message content %q, got %q", "Working on it...", info.Messages[1].Content)
+	if first["type"] != "system" {
+		t.Errorf("expected first message type %q, got %v", "system", first["type"])
 	}
-	if info.Messages[2].Content != "Using tool: Bash" {
-		t.Errorf("expected third message content %q, got %q", "Using tool: Bash", info.Messages[2].Content)
+	if first["session_id"] != "sess-001" {
+		t.Errorf("expected session_id %q, got %v", "sess-001", first["session_id"])
 	}
 }
 
 func TestMessagesTool_Empty(t *testing.T) {
 	mock := &mockPrompter{
-		messagesInfo: claudepkg.MessagesInfo{
+		rawMessagesInfo: claudepkg.RawMessagesInfo{
 			Status: claudepkg.ProcessStatusIdle,
 		},
 	}
@@ -890,7 +910,7 @@ func TestMessagesTool_Empty(t *testing.T) {
 	}
 
 	text := extractText(t, result)
-	var info claudepkg.MessagesInfo
+	var info claudepkg.RawMessagesInfo
 	if err := json.Unmarshal([]byte(text), &info); err != nil {
 		t.Fatalf("failed to parse messages JSON: %v (text: %s)", err, text)
 	}
@@ -900,6 +920,161 @@ func TestMessagesTool_Empty(t *testing.T) {
 	}
 	if len(info.Messages) != 0 {
 		t.Errorf("expected 0 messages, got %d", len(info.Messages))
+	}
+}
+
+func TestMessagesTool_WithOffset(t *testing.T) {
+	mock := &mockPrompter{
+		rawMessagesInfo: claudepkg.RawMessagesInfo{
+			Status:   claudepkg.ProcessStatusBusy,
+			Total:    5,
+			Messages: []json.RawMessage{json.RawMessage(`{"type":"result","result":"done"}`)},
+		},
+	}
+
+	tools := buildToolMap(mock)
+	handler := tools["messages"]
+
+	request := newCallToolRequest("messages", map[string]any{
+		"offset": float64(4),
+	})
+
+	result, err := handler(context.Background(), request)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected tool error: %v", result.Content)
+	}
+
+	if mock.lastRawOffset != 4 {
+		t.Errorf("expected offset 4, got %d", mock.lastRawOffset)
+	}
+	if mock.lastRawTypes != nil {
+		t.Errorf("expected nil types, got %v", mock.lastRawTypes)
+	}
+}
+
+func TestMessagesTool_WithTypes(t *testing.T) {
+	mock := &mockPrompter{
+		rawMessagesInfo: claudepkg.RawMessagesInfo{
+			Status: claudepkg.ProcessStatusBusy,
+			Total:  10,
+			Messages: []json.RawMessage{
+				json.RawMessage(`{"type":"assistant","subtype":"text","text":"hello"}`),
+			},
+		},
+	}
+
+	tools := buildToolMap(mock)
+	handler := tools["messages"]
+
+	request := newCallToolRequest("messages", map[string]any{
+		"types": "assistant,result",
+	})
+
+	result, err := handler(context.Background(), request)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected tool error: %v", result.Content)
+	}
+
+	if mock.lastRawOffset != 0 {
+		t.Errorf("expected offset 0, got %d", mock.lastRawOffset)
+	}
+	if len(mock.lastRawTypes) != 2 {
+		t.Fatalf("expected 2 types, got %d", len(mock.lastRawTypes))
+	}
+	if mock.lastRawTypes[0] != "assistant" || mock.lastRawTypes[1] != "result" {
+		t.Errorf("expected types [assistant result], got %v", mock.lastRawTypes)
+	}
+}
+
+func TestMessagesTool_WithOffsetAndTypes(t *testing.T) {
+	mock := &mockPrompter{
+		rawMessagesInfo: claudepkg.RawMessagesInfo{
+			Status: claudepkg.ProcessStatusBusy,
+			Total:  20,
+		},
+	}
+
+	tools := buildToolMap(mock)
+	handler := tools["messages"]
+
+	request := newCallToolRequest("messages", map[string]any{
+		"offset": float64(10),
+		"types":  "system",
+	})
+
+	result, err := handler(context.Background(), request)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected tool error: %v", result.Content)
+	}
+
+	if mock.lastRawOffset != 10 {
+		t.Errorf("expected offset 10, got %d", mock.lastRawOffset)
+	}
+	if len(mock.lastRawTypes) != 1 || mock.lastRawTypes[0] != "system" {
+		t.Errorf("expected types [system], got %v", mock.lastRawTypes)
+	}
+}
+
+func TestMessagesTool_NegativeOffset(t *testing.T) {
+	mock := &mockPrompter{}
+	tools := buildToolMap(mock)
+	handler := tools["messages"]
+
+	request := newCallToolRequest("messages", map[string]any{
+		"offset": float64(-1),
+	})
+
+	result, err := handler(context.Background(), request)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.IsError {
+		t.Error("expected error for negative offset")
+	}
+}
+
+func TestMessagesTool_FractionalOffset(t *testing.T) {
+	mock := &mockPrompter{}
+	tools := buildToolMap(mock)
+	handler := tools["messages"]
+
+	request := newCallToolRequest("messages", map[string]any{
+		"offset": 2.5,
+	})
+
+	result, err := handler(context.Background(), request)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.IsError {
+		t.Error("expected error for fractional offset")
+	}
+}
+
+func TestMessagesTool_InvalidType(t *testing.T) {
+	mock := &mockPrompter{}
+	tools := buildToolMap(mock)
+	handler := tools["messages"]
+
+	request := newCallToolRequest("messages", map[string]any{
+		"types": "assistant,bogus",
+	})
+
+	result, err := handler(context.Background(), request)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.IsError {
+		t.Error("expected error for invalid message type")
 	}
 }
 

--- a/pkg/server/handlers_test.go
+++ b/pkg/server/handlers_test.go
@@ -57,6 +57,10 @@ func (m *mockPrompter) Messages() claude.MessagesInfo {
 	return claude.MessagesInfo{Status: m.status.Status}
 }
 
+func (m *mockPrompter) RawMessages(_ int, _ []string) claude.RawMessagesInfo {
+	return claude.RawMessagesInfo{Status: m.status.Status}
+}
+
 func (m *mockPrompter) MarshalStatus() ([]byte, error) {
 	return json.Marshal(m.status)
 }


### PR DESCRIPTION
## Summary

- Replace lossy `MessageSummary` output with raw JSON passthrough in the `messages` MCP tool, preserving tool arguments, tool results, user messages, and combined text+tool_use content previously dropped by `SummarizeMessages()`
- Add `offset` parameter for efficient follow mode (skip first N messages, return from N onward)
- Add `types` parameter for filtering by message type (comma-separated: `system`, `assistant`, `user`, `result`)
- Response includes `total` field with unfiltered message count for detecting new messages

## Approach

Added `RawMessagesInfo` struct and `RawMessages(offset int, types []string)` method to the `Prompter` interface, with implementations on both `Process` and `PersistentProcess`. The method follows the same multi-source fallback pattern as the existing `Messages()` method (live messages → result messages → disk-persisted state).

The `collectRawMessages` helper applies offset and type filtering on `StreamMessage` slices, returning `msg.Raw` bytes directly. Input validation in the MCP handler rejects negative/fractional offsets and unknown type values.

The existing `SummarizeMessages` code and `Messages()` method remain for other internal uses.

Closes #148

## Test plan

- [x] Existing messages tool tests updated to verify raw JSON format with `total` field
- [x] New tests for offset parameter (including offset beyond total, offset+type filter combination)
- [x] New tests for types parameter (single type, multiple types, combined with offset)
- [x] New tests for input validation (negative offset, fractional offset, invalid type)
- [x] Process-level tests for `RawMessages` across idle, busy, and completed states
- [x] `go build ./...`, `go vet ./...`, `go test ./...` all pass
- [x] Reviewed by `base:code-reviewer` and `code-quality:security-auditor`

🤖 Generated with [Claude Code](https://claude.com/claude-code)