### PR TITLE
ci: tag images as :latest on main branch pushes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,6 +113,52 @@ workflows:
             ignore:
             - main
 
+    # Main branch: tag images as :latest
+    - architect/push-to-registries-multiarch:
+        context: architect
+        name: push-to-registries-latest
+        tag-latest-branch: main
+        requires:
+        - go-build-klaus
+        filters:
+          branches:
+            only: main
+
+    - architect/push-to-registries-multiarch:
+        context: architect
+        name: push-to-registries-debian-latest
+        image: giantswarm/klaus-debian
+        dockerfile: ./Dockerfile.debian
+        tag-latest-branch: main
+        requires:
+        - go-build-klaus
+        filters:
+          branches:
+            only: main
+
+    - architect/push-to-registries-multiarch:
+        context: architect
+        name: push-to-toolchains-latest
+        image: giantswarm/klaus-toolchains/base
+        tag-latest-branch: main
+        requires:
+        - go-build-klaus
+        filters:
+          branches:
+            only: main
+
+    - architect/push-to-registries-multiarch:
+        context: architect
+        name: push-to-toolchains-debian-latest
+        image: giantswarm/klaus-toolchains/base-debian
+        dockerfile: ./Dockerfile.debian
+        tag-latest-branch: main
+        requires:
+        - go-build-klaus
+        filters:
+          branches:
+            only: main
+
     # Tag builds: full multi-arch (amd64 + arm64)
     - architect/push-to-registries-multiarch:
         context: architect


### PR DESCRIPTION
## Summary

- Add 4 dedicated `main`-branch push jobs with `tag-latest-branch: main` for all image variants (`klaus`, `klaus-debian`, `klaus-toolchains/base`, `klaus-toolchains/base-debian`)
- When a PR merges to `main` (which follows every release tag), these jobs run and update the `:latest` tag in the registry
- Branch builds (non-main) and tag builds continue working exactly as before

## Why

The `:latest` image tag was stale because:
1. Tag builds set `branches: ignore: /.*/`, so `CIRCLE_BRANCH` is empty and `tag-latest-branch` never matches
2. Branch builds explicitly ignored `main`

Closes #165

## Test plan

- [ ] CI passes on this PR (branch build, amd64 only)
- [ ] After merge, the main-branch pipeline runs the 4 new `*-latest` jobs
- [ ] Registry `:latest` tag is updated to match the current `main` HEAD

🤖 Generated with [Claude Code](https://claude.com/claude-code)