### PR TITLE
fix: derive version from git during Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,12 +11,15 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . .
-ARG VERSION=dev
-ARG COMMIT=unknown
-ARG DATE=unknown
+ARG VERSION=
+ARG COMMIT=
+ARG DATE=
 ARG TARGETOS
 ARG TARGETARCH
-RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -trimpath \
+RUN VERSION=${VERSION:-$(git describe --tags --always --dirty 2>/dev/null || echo "dev")} && \
+    COMMIT=${COMMIT:-$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")} && \
+    DATE=${DATE:-$(date -u +%Y-%m-%dT%H:%M:%SZ)} && \
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -trimpath \
     -ldflags "-w -extldflags '-static' \
     -X 'main.version=${VERSION}' \
     -X 'main.commit=${COMMIT}' \

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -15,12 +15,15 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . .
-ARG VERSION=dev
-ARG COMMIT=unknown
-ARG DATE=unknown
+ARG VERSION=
+ARG COMMIT=
+ARG DATE=
 ARG TARGETOS
 ARG TARGETARCH
-RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -trimpath \
+RUN VERSION=${VERSION:-$(git describe --tags --always --dirty 2>/dev/null || echo "dev")} && \
+    COMMIT=${COMMIT:-$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")} && \
+    DATE=${DATE:-$(date -u +%Y-%m-%dT%H:%M:%SZ)} && \
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -trimpath \
     -ldflags "-w -extldflags '-static' \
     -X 'main.version=${VERSION}' \
     -X 'main.commit=${COMMIT}' \


### PR DESCRIPTION
## Summary

- Replace static `ARG VERSION=dev` / `COMMIT=unknown` / `DATE=unknown` with empty defaults
- Extract version, commit, and date from git metadata during the Docker build via `git describe`, `git rev-parse`, and `date`
- Fall back to ARG values when `--build-arg` is passed, enabling manual overrides

This makes `klaus --version` report the actual git tag (e.g. `v0.0.86`) on release builds and a descriptive version (e.g. `v0.0.86-2-gabc1234`) on branch builds, without any changes to the architect orb or CircleCI config.

Both `Dockerfile` and `Dockerfile.debian` are updated (the latter regenerated via `make generate-dockerfile-debian`).

Fixes #167

Made with [Cursor](https://cursor.com)