### PR TITLE
Fix helm-schema rename in pre-commit workflow

### DIFF
--- a/.github/workflows/zz_generated.pre-commit.yaml
+++ b/.github/workflows/zz_generated.pre-commit.yaml
@@ -41,6 +41,6 @@ jobs:
         version: "${{ env.HELM_VALUES_SCHEMA_JSON_VERSION }}"
         download_url: "https://github.com/losisin/helm-values-schema-json/releases/download/v${version}/helm-values-schema-json_${version}_linux_amd64.tgz"
         tarball_binary_path: "schema"
-        binary_new_name: "${binary}"
+        binary_new_name: "helm-schema"
     - name: Execute pre-commit hooks
       uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1


### PR DESCRIPTION
## Problem

Pre-commit CI on this repo fails with:

```
##[error]Unable to locate executable file: helm-schema. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable.
```

The `Install helm-values-schema-json` step in `.github/workflows/zz_generated.pre-commit.yaml` passes `binary_new_name: "${binary}"`, but [`giantswarm/install-binary-action`](https://github.com/giantswarm/install-binary-action/blob/main/index.js) does **not** template-expand `${binary}` in `binary_new_name`. As a result, `tar --transform=s/schema/${binary}/` renames the extracted file to the literal string `${binary}`, and the smoke test (`helm-schema version`) cannot find the binary on PATH.

## Fix

Sync the central template fix from giantswarm/github#5082 (already merged on main): replace `binary_new_name: "${binary}"` with `binary_new_name: "helm-schema"` in `.github/workflows/zz_generated.pre-commit.yaml`. Renovate would otherwise propagate this eventually, but multiple Renovate PRs in this repo are blocked on pre-commit right now.

## Acceptance criteria

- pre-commit job is green on this PR.
- pre-commit job is green on `main` after merge.
- No other change in workflow behavior.

Made with [Cursor](https://cursor.com)