### PR TITLE
ci: fix pre-commit auto-formatter violations

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,11 @@
+version: "2"
+
+linters:
+  exclusions:
+    rules:
+      # goconst flags repeated string literals; tests naturally repeat
+      # strings (JSON payloads, status values, message types) and should
+      # not be forced to hoist them to constants.
+      - path: _test\.go
+        linters:
+          - goconst

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -262,7 +262,7 @@ func runServe(portFlag string, cfg config.Config, enableOAuth bool, oauthConfig 
 	// Derive NoSessionPersistence from mode: agent -> true, chat -> false.
 	// DefaultOptions() already sets NoSessionPersistence=true (agent default),
 	// so only override for chat mode.
-	if cfg.Claude.Mode == "chat" {
+	if cfg.Claude.Mode == server.ModeChat {
 		opts.NoSessionPersistence = false
 	}
 
@@ -286,7 +286,7 @@ func runServe(portFlag string, cfg config.Config, enableOAuth bool, oauthConfig 
 	// Note: permissionMode and effort are already validated by cfg.Validate()
 	// using the canonical validators from the claude package.
 	var process claude.Prompter
-	if cfg.Claude.Mode == "chat" {
+	if cfg.Claude.Mode == server.ModeChat {
 		log.Println("Starting in chat mode (bidirectional stream-json)")
 		process = claude.NewPersistentProcess(opts)
 	} else {
@@ -309,7 +309,7 @@ func runServe(portFlag string, cfg config.Config, enableOAuth bool, oauthConfig 
 	defer serverCancel()
 
 	mode := server.ModeAgent
-	if cfg.Claude.Mode == "chat" {
+	if cfg.Claude.Mode == server.ModeChat {
 		mode = server.ModeChat
 	}
 
@@ -498,14 +498,14 @@ func soulFilePath() string {
 // nil error when the file does not exist. Returns an error if the file
 // exceeds maxSOULFileSize.
 func loadSOULFile(path string) (string, error) {
-	f, err := os.Open(path)
+	f, err := os.Open(path) // #nosec G304 -- path is sourced from trusted config/env
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return "", nil
 		}
 		return "", err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	limited := io.LimitReader(f, maxSOULFileSize+1)
 	data, err := io.ReadAll(limited)

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -12,7 +12,7 @@ func TestLoadSOULFile_Exists(t *testing.T) {
 	path := filepath.Join(dir, "SOUL.md")
 	content := "You are Klaus, a helpful AI assistant."
 
-	if err := os.WriteFile(path, []byte(content), 0o444); err != nil {
+	if err := os.WriteFile(path, []byte(content), 0o400); err != nil {
 		t.Fatalf("failed to write temp SOUL.md: %v", err)
 	}
 
@@ -39,7 +39,7 @@ func TestLoadSOULFile_EmptyFile(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "SOUL.md")
 
-	if err := os.WriteFile(path, []byte(""), 0o444); err != nil {
+	if err := os.WriteFile(path, []byte(""), 0o400); err != nil {
 		t.Fatalf("failed to write temp SOUL.md: %v", err)
 	}
 
@@ -56,7 +56,7 @@ func TestLoadSOULFile_WhitespaceOnly(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "SOUL.md")
 
-	if err := os.WriteFile(path, []byte("  \n\n  \t  \n"), 0o444); err != nil {
+	if err := os.WriteFile(path, []byte("  \n\n  \t  \n"), 0o400); err != nil {
 		t.Fatalf("failed to write temp SOUL.md: %v", err)
 	}
 
@@ -74,7 +74,7 @@ func TestLoadSOULFile_TrimsWhitespace(t *testing.T) {
 	path := filepath.Join(dir, "SOUL.md")
 	content := "\n\n  You are a coding assistant.\n\n"
 
-	if err := os.WriteFile(path, []byte(content), 0o444); err != nil {
+	if err := os.WriteFile(path, []byte(content), 0o400); err != nil {
 		t.Fatalf("failed to write temp SOUL.md: %v", err)
 	}
 
@@ -112,7 +112,7 @@ func TestLoadSOULFile_MultilineContent(t *testing.T) {
 	path := filepath.Join(dir, "SOUL.md")
 	content := "# Klaus Personality\n\nYou are Klaus.\nYou help with code.\n\n## Traits\n- Helpful\n- Concise"
 
-	if err := os.WriteFile(path, []byte(content), 0o444); err != nil {
+	if err := os.WriteFile(path, []byte(content), 0o400); err != nil {
 		t.Fatalf("failed to write temp SOUL.md: %v", err)
 	}
 
@@ -131,7 +131,7 @@ func TestLoadSOULFile_ExceedsMaxSize(t *testing.T) {
 
 	// Create a file that is one byte over the limit.
 	data := strings.Repeat("A", maxSOULFileSize+1)
-	if err := os.WriteFile(path, []byte(data), 0o444); err != nil {
+	if err := os.WriteFile(path, []byte(data), 0o400); err != nil {
 		t.Fatalf("failed to write oversized SOUL.md: %v", err)
 	}
 
@@ -150,7 +150,7 @@ func TestLoadSOULFile_ExactlyMaxSize(t *testing.T) {
 
 	// Create a file at exactly the limit -- should succeed.
 	data := strings.Repeat("B", maxSOULFileSize)
-	if err := os.WriteFile(path, []byte(data), 0o444); err != nil {
+	if err := os.WriteFile(path, []byte(data), 0o400); err != nil {
 		t.Fatalf("failed to write SOUL.md: %v", err)
 	}
 
@@ -166,7 +166,7 @@ func TestLoadSOULFile_ExactlyMaxSize(t *testing.T) {
 func TestSoulFilePath_Unset(t *testing.T) {
 	// Ensure the env var is saved/restored, then unset it.
 	t.Setenv("KLAUS_SOUL_FILE", "")
-	os.Unsetenv("KLAUS_SOUL_FILE")
+	_ = os.Unsetenv("KLAUS_SOUL_FILE")
 
 	got := soulFilePath()
 	if got != defaultSOULPath {

--- a/pkg/claude/message.go
+++ b/pkg/claude/message.go
@@ -31,6 +31,16 @@ const (
 	SubtypeToolUse MessageSubtype = "tool_use"
 )
 
+// Stream event type names emitted by the Claude CLI inside stream_event envelopes.
+const (
+	EventContentBlockStart = "content_block_start"
+	EventContentBlockDelta = "content_block_delta"
+	EventContentBlockStop  = "content_block_stop"
+)
+
+// Tool name for the bash command execution tool.
+const ToolNameBash = "Bash"
+
 // TokenUsage holds per-message token counts from the Claude API usage object.
 type TokenUsage struct {
 	InputTokens              int64 `json:"input_tokens,omitempty"`
@@ -107,7 +117,7 @@ func ParseStreamMessage(data []byte) (StreamMessage, error) {
 			if env.Event.Delta.Type == "input_json_delta" {
 				msg.InputJSONDelta = env.Event.Delta.PartialJSON
 			}
-			if env.Event.Type == "content_block_start" && env.Event.ContentBlock.Type == "tool_use" {
+			if env.Event.Type == EventContentBlockStart && env.Event.ContentBlock.Type == string(SubtypeToolUse) {
 				msg.ToolUseName = env.Event.ContentBlock.Name
 				msg.ToolUseBlockID = env.Event.ContentBlock.ID
 			}
@@ -126,7 +136,7 @@ func ParseStreamMessage(data []byte) (StreamMessage, error) {
 			textLen := 0
 			for _, block := range env.Content {
 				switch block.Type {
-				case "text":
+				case string(SubtypeText):
 					if msg.Subtype == "" {
 						msg.Subtype = SubtypeText
 					}
@@ -140,7 +150,7 @@ func ParseStreamMessage(data []byte) (StreamMessage, error) {
 					}
 					msg.Text += t
 					textLen += len(t)
-				case "tool_use":
+				case string(SubtypeToolUse):
 					if msg.Subtype == SubtypeToolUse {
 						continue // keep the first tool_use block
 					}
@@ -289,7 +299,7 @@ func SummarizeMessages(msgs []StreamMessage) []MessageSummary {
 			continue
 		}
 		// Deduplicate system messages by content.
-		if s.Role == "system" {
+		if s.Role == string(MessageTypeSystem) {
 			if seenSystem[s.Content] {
 				continue
 			}
@@ -398,6 +408,12 @@ func summarizeMessage(msg StreamMessage) MessageSummary {
 func Float64Ptr(f float64) *float64 {
 	return &f
 }
+
+// Subagent status values reported in SubagentCall.Status.
+const (
+	SubagentStatusRunning   = "running"
+	SubagentStatusCompleted = "completed"
+)
 
 // SubagentCall tracks a single subagent dispatch via the Task/Agent tool.
 type SubagentCall struct {
@@ -515,7 +531,7 @@ func ExtractToolResults(msg StreamMessage) []ToolResultBlock {
 // whose output may contain real PR URLs (as opposed to file content tools like
 // Read/Write that may contain PR URLs embedded in source code or docs).
 func isBashTool(name string) bool {
-	return name == "Bash" || name == "bash"
+	return name == ToolNameBash || name == "bash"
 }
 
 // maxPRURLsPerBlock caps the number of PR URLs extracted from a single content block.

--- a/pkg/claude/openai.go
+++ b/pkg/claude/openai.go
@@ -90,7 +90,7 @@ func ToOpenAIMessages(msgs []StreamMessage) ([]OpenAIMessage, OpenAIMetadata) {
 	// Track the current assistant message being consolidated.
 	// We merge consecutive assistant messages with the same message.id.
 	var currentAssistantID string
-	var currentAssistantIdx int = -1
+	currentAssistantIdx := -1
 
 	for _, msg := range msgs {
 		switch msg.Type {
@@ -265,11 +265,11 @@ func buildAssistantFromBlocks(blocks []openaiContentBlock) *OpenAIMessage {
 
 	for _, block := range blocks {
 		switch block.Type {
-		case "text":
+		case string(SubtypeText):
 			if block.Text != "" {
 				textParts = append(textParts, block.Text)
 			}
-		case "tool_use":
+		case string(SubtypeToolUse):
 			argsStr := "{}"
 			if len(block.Input) > 0 {
 				argsStr = string(block.Input)

--- a/pkg/claude/options_test.go
+++ b/pkg/claude/options_test.go
@@ -316,13 +316,13 @@ func TestBaseArgs_MCPAllowedToolsPatterns(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create temp file: %v", err)
 	}
-	defer os.Remove(tmpFile.Name())
+	defer func() { _ = os.Remove(tmpFile.Name()) }()
 
 	mcpConfig := `{"mcpServers":{"muster":{"command":"muster"},"github":{"command":"gh"}}}`
 	if _, err := tmpFile.WriteString(mcpConfig); err != nil {
 		t.Fatalf("failed to write temp file: %v", err)
 	}
-	tmpFile.Close()
+	_ = tmpFile.Close()
 
 	opts := Options{MCPConfigPath: tmpFile.Name()}
 	args := opts.baseArgs()
@@ -358,12 +358,12 @@ func TestBaseArgs_MCPAllowedToolsInvalidJSON(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create temp file: %v", err)
 	}
-	defer os.Remove(tmpFile.Name())
+	defer func() { _ = os.Remove(tmpFile.Name()) }()
 
 	if _, err := tmpFile.WriteString("not valid json"); err != nil {
 		t.Fatalf("failed to write temp file: %v", err)
 	}
-	tmpFile.Close()
+	_ = tmpFile.Close()
 
 	opts := Options{MCPConfigPath: tmpFile.Name()}
 	args := opts.baseArgs()
@@ -380,12 +380,12 @@ func TestBaseArgs_MCPAllowedToolsEmptyServers(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create temp file: %v", err)
 	}
-	defer os.Remove(tmpFile.Name())
+	defer func() { _ = os.Remove(tmpFile.Name()) }()
 
 	if _, err := tmpFile.WriteString(`{"mcpServers":{}}`); err != nil {
 		t.Fatalf("failed to write temp file: %v", err)
 	}
-	tmpFile.Close()
+	_ = tmpFile.Close()
 
 	opts := Options{MCPConfigPath: tmpFile.Name()}
 	args := opts.baseArgs()

--- a/pkg/claude/persistent_test.go
+++ b/pkg/claude/persistent_test.go
@@ -497,11 +497,11 @@ func main() {
 	tmpDir := t.TempDir()
 	srcPath := tmpDir + "/crash_helper.go"
 	binPath := tmpDir + "/crash_helper"
-	if err := os.WriteFile(srcPath, []byte(helperSrc), 0644); err != nil {
+	if err := os.WriteFile(srcPath, []byte(helperSrc), 0o600); err != nil {
 		t.Fatalf("failed to write helper source: %v", err)
 	}
 
-	buildCmd := exec.Command("go", "build", "-o", binPath, srcPath)
+	buildCmd := exec.Command("go", "build", "-o", binPath, srcPath) // #nosec G204 -- test helper with trusted paths
 	if out, err := buildCmd.CombinedOutput(); err != nil {
 		t.Fatalf("failed to build helper: %v\n%s", err, out)
 	}
@@ -523,7 +523,7 @@ func main() {
 	}
 
 	// Launch the helper binary as the "claude" subprocess.
-	cmd := exec.Command(binPath)
+	cmd := exec.Command(binPath) // #nosec G204 -- test helper with trusted path
 	stdinPipe, err := cmd.StdinPipe()
 	if err != nil {
 		t.Fatalf("stdin pipe: %v", err)

--- a/pkg/claude/resultstore.go
+++ b/pkg/claude/resultstore.go
@@ -153,12 +153,12 @@ func (s *ResultStore) Save(result PersistedResult) error {
 	tmpName := tmp.Name()
 
 	if _, err := tmp.Write(data); err != nil {
-		tmp.Close()
+		_ = tmp.Close()
 		_ = os.Remove(tmpName)
 		return fmt.Errorf("writing result file: %w", err)
 	}
 	if err := tmp.Chmod(0o600); err != nil {
-		tmp.Close()
+		_ = tmp.Close()
 		_ = os.Remove(tmpName)
 		return fmt.Errorf("setting file permissions: %w", err)
 	}
@@ -180,7 +180,7 @@ func (s *ResultStore) Save(result PersistedResult) error {
 func (s *ResultStore) Load() (*PersistedResult, error) {
 	path := filepath.Join(s.dir, resultFileName)
 
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(path) // #nosec G304 -- path is confined to ResultStore.dir
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil

--- a/pkg/claude/resultstore_test.go
+++ b/pkg/claude/resultstore_test.go
@@ -184,7 +184,7 @@ func TestResultStore_LoadCorruptFile(t *testing.T) {
 
 	// Write corrupt data.
 	path := filepath.Join(dir, resultFileName)
-	if err := os.WriteFile(path, []byte("not json"), 0o640); err != nil {
+	if err := os.WriteFile(path, []byte("not json"), 0o600); err != nil {
 		t.Fatalf("failed to write corrupt file: %v", err)
 	}
 

--- a/pkg/claude/subagent.go
+++ b/pkg/claude/subagent.go
@@ -73,7 +73,7 @@ func (st *subagentTracker) handleToolUse(msg StreamMessage) bool {
 
 	call := SubagentCall{
 		ToolID: msg.ToolID,
-		Status: "running",
+		Status: SubagentStatusRunning,
 	}
 
 	// Parse the tool arguments to extract subagent_type and description.
@@ -153,7 +153,7 @@ func (st *subagentTracker) completeSubagent(toolID string, inf inflightSubagent,
 	delete(st.inflight, toolID)
 
 	call := inf.call
-	call.Status = "completed"
+	call.Status = SubagentStatusCompleted
 	call.DurationMS = float64(time.Since(inf.start).Milliseconds())
 
 	// Try to parse the <usage> block from the result content.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -175,7 +175,7 @@ func Load(path string) (Config, error) {
 		}
 		// File doesn't exist -- env-only mode (backward compat).
 	} else {
-		defer f.Close()
+		defer func() { _ = f.Close() }()
 		limited := io.LimitReader(f, maxConfigFileSize+1)
 		data, readErr := io.ReadAll(limited)
 		if readErr != nil {
@@ -334,7 +334,7 @@ func envOverrideInt(target *int, key string) {
 	if v := os.Getenv(key); v != "" {
 		n, err := strconv.Atoi(v)
 		if err != nil {
-			log.Printf("WARNING: ignoring invalid integer for %s=%q: %v", key, v, err)
+			log.Printf("WARNING: ignoring invalid integer for %s=%q: %v", key, v, err) // #nosec G706 -- value is safely quoted via %q
 			return
 		}
 		*target = n
@@ -345,7 +345,7 @@ func envOverrideFloat64(target *float64, key string) {
 	if v := os.Getenv(key); v != "" {
 		f, err := strconv.ParseFloat(v, 64)
 		if err != nil {
-			log.Printf("WARNING: ignoring invalid float for %s=%q: %v", key, v, err)
+			log.Printf("WARNING: ignoring invalid float for %s=%q: %v", key, v, err) // #nosec G706 -- value is safely quoted via %q
 			return
 		}
 		*target = f

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -88,7 +88,7 @@ oauth:
     keyFile: "/etc/tls/key.pem"
   disableStreaming: true
 `
-	if err := os.WriteFile(path, []byte(yaml), 0o644); err != nil {
+	if err := os.WriteFile(path, []byte(yaml), 0o600); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
 
@@ -161,7 +161,7 @@ claude:
 server:
   port: "9090"
 `
-	if err := os.WriteFile(path, []byte(yaml), 0o644); err != nil {
+	if err := os.WriteFile(path, []byte(yaml), 0o600); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
 
@@ -184,7 +184,7 @@ func TestLoad_InvalidYAML(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "bad.yaml")
 
-	if err := os.WriteFile(path, []byte("{{not: valid: yaml:"), 0o644); err != nil {
+	if err := os.WriteFile(path, []byte("{{not: valid: yaml:"), 0o600); err != nil {
 		t.Fatalf("write: %v", err)
 	}
 
@@ -399,7 +399,7 @@ func TestMode_EnvOverridesYAML(t *testing.T) {
 claude:
   mode: chat
 `
-	if err := os.WriteFile(path, []byte(yaml), 0o644); err != nil {
+	if err := os.WriteFile(path, []byte(yaml), 0o600); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
 
@@ -424,7 +424,7 @@ func TestMode_YAMLConfig(t *testing.T) {
 claude:
   mode: chat
 `
-	if err := os.WriteFile(path, []byte(yaml), 0o644); err != nil {
+	if err := os.WriteFile(path, []byte(yaml), 0o600); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
 

--- a/pkg/server/chat.go
+++ b/pkg/server/chat.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	claudepkg "github.com/giantswarm/klaus/pkg/claude"
+	"github.com/giantswarm/klaus/pkg/project"
 )
 
 // OpenAI-compatible request/response types for the chat completions endpoint.
@@ -60,6 +61,10 @@ type chatCompletionUse struct {
 	TotalTokens      int `json:"total_tokens"`
 }
 
+// finishReasonStop is the OpenAI-compatible finish_reason value emitted
+// when a completion terminates normally.
+const finishReasonStop = "stop"
+
 // handleChatCompletions returns an http.HandlerFunc that accepts an
 // OpenAI-compatible chat completion request and streams the response as SSE
 // (or returns a complete response for non-streaming requests).
@@ -106,7 +111,7 @@ func handleChatCompletions(process claudepkg.Prompter) http.HandlerFunc {
 
 		model := req.Model
 		if model == "" {
-			model = "klaus"
+			model = project.Name
 		}
 
 		if req.Stream {
@@ -184,7 +189,7 @@ func streamResponse(w http.ResponseWriter, r *http.Request, process claudepkg.Pr
 				log.Printf("[chat] failed to marshal SSE chunk: %v", err)
 				continue
 			}
-			fmt.Fprintf(w, "data: %s\n\n", data)
+			_, _ = fmt.Fprintf(w, "data: %s\n\n", data)
 			flusher.Flush()
 		}
 	}
@@ -192,7 +197,7 @@ func streamResponse(w http.ResponseWriter, r *http.Request, process claudepkg.Pr
 
 // writeDoneChunk sends the final SSE chunk with finish_reason "stop" and the [DONE] sentinel.
 func writeDoneChunk(w http.ResponseWriter, flusher http.Flusher, id, model string, usage *chatCompletionUse) {
-	stop := "stop"
+	stop := finishReasonStop
 	final := chatCompletionResponse{
 		ID:      id,
 		Object:  "chat.completion.chunk",
@@ -206,8 +211,8 @@ func writeDoneChunk(w http.ResponseWriter, flusher http.Flusher, id, model strin
 		log.Printf("[chat] failed to marshal final SSE chunk: %v", err)
 		return
 	}
-	fmt.Fprintf(w, "data: %s\n\n", data)
-	fmt.Fprint(w, "data: [DONE]\n\n")
+	_, _ = fmt.Fprintf(w, "data: %s\n\n", data)
+	_, _ = fmt.Fprint(w, "data: [DONE]\n\n")
 	flusher.Flush()
 }
 
@@ -234,7 +239,7 @@ func collectResponse(w http.ResponseWriter, ch <-chan claudepkg.StreamMessage, m
 
 	resultText := claudepkg.CollectResultText(msgs)
 
-	stop := "stop"
+	stop := finishReasonStop
 	resp := chatCompletionResponse{
 		ID:      fmt.Sprintf("chatcmpl-%d", time.Now().UnixNano()),
 		Object:  "chat.completion",

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -26,7 +26,7 @@ type statusResponse struct {
 
 func handleHealthz(w http.ResponseWriter, _ *http.Request) {
 	w.WriteHeader(http.StatusOK)
-	fmt.Fprintln(w, "ok")
+	_, _ = fmt.Fprintln(w, "ok")
 }
 
 // handleReadyz reports whether the Claude process is ready to accept traffic.
@@ -37,11 +37,11 @@ func handleReadyz(process claudepkg.Prompter) http.HandlerFunc {
 		switch status {
 		case claudepkg.ProcessStatusStarting, claudepkg.ProcessStatusError, claudepkg.ProcessStatusStopped:
 			w.WriteHeader(http.StatusServiceUnavailable)
-			fmt.Fprintln(w, "not ready")
+			_, _ = fmt.Fprintln(w, "not ready")
 			return
 		default:
 			w.WriteHeader(http.StatusOK)
-			fmt.Fprintln(w, "ok")
+			_, _ = fmt.Fprintln(w, "ok")
 		}
 	}
 }
@@ -53,7 +53,7 @@ func handleRoot(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
-	fmt.Fprintf(w, "%s %s\n", project.Name, project.Version())
+	_, _ = fmt.Fprintf(w, "%s %s\n", project.Name, project.Version())
 }
 
 func handleStatus(process claudepkg.Prompter, mode string, ownerSubject string) http.HandlerFunc {


### PR DESCRIPTION
## Summary

The pre-commit workflow (driven by the shared `giantswarm/github` template) now enforces `gosec`, `goconst`, `govet`, and the default golangci-lint linters (`errcheck`, `staticcheck`) across the repo. `main` has been failing pre-commit CI because of pre-existing violations, which cascades into every Renovate PR.

This PR fixes the underlying repository state so those PRs can be rebased and merged.

## Changes

- **errcheck (18)**: Explicitly discard error returns with `_ = fn()` / `defer func() { _ = fn() }()` for `Close`/`Remove`/`Unsetenv` and `fmt.Fprint*` where the I/O sink is a trusted `http.ResponseWriter`.
- **gosec (20)**:
  - `G304` on `os.Open`/`os.ReadFile` for operator-provided config paths: annotated with `#nosec`.
  - `G306` file permissions in tests: tightened `0o444` → `0o400`, `0o644`/`0o640` → `0o600`.
  - `G204` test-helper subprocess invocations: annotated with `#nosec`.
  - `G706` log injection: annotated with `#nosec` (value is already quoted via `%q`).
- **goconst (27)**:
  - Production code: new constants `EventContentBlockStart`, `ToolNameBash`, `SubagentStatusRunning`/`Completed`, `finishReasonStop`, `project.Name`, and reuse of existing `server.ModeChat`, `SubtypeText`/`SubtypeToolUse`, `MessageTypeSystem`.
  - Test code: exclude from `goconst` via a minimal `.golangci.yml`. Tests naturally repeat status values and JSON payloads, so forcing constant extraction hurts readability without improving safety (standard golangci-lint practice).
- **staticcheck QF1011**: Drop redundant `int` in `var currentAssistantIdx int = -1`.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` all packages pass
- [x] `golangci-lint run -E=gosec -E=goconst -E=govet --max-same-issues=0 --max-issues-per-linter=0 ./...` reports 0 issues
- [x] `gofmt -l .` clean
- [x] `goimports -l -local github.com/giantswarm/klaus .` clean
- [x] `go mod tidy` leaves go.mod/go.sum unchanged
- [ ] CI pre-commit passes