### PR TITLE
test(ats): tighten smoke-test timeout and rerun budget

### DIFF
--- a/tests/ats/test_basic_cluster.py
+++ b/tests/ats/test_basic_cluster.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 deployment_name = "klaus"
 namespace_name = "klaus"
 
-timeout: int = 560
+timeout: int = 180
 
 
 @pytest.mark.smoke
@@ -44,7 +44,7 @@ def wait_for_deployment(kube_cluster: Cluster) -> List[pykube.Deployment]:
 
 @pytest.mark.smoke
 @pytest.mark.upgrade
-@pytest.mark.flaky(reruns=5, reruns_delay=10)
+@pytest.mark.flaky(reruns=1, reruns_delay=15)
 def test_pods_available(kube_cluster: Cluster, deployment: List[pykube.Deployment]):
     for s in deployment:
         assert int(s.obj["status"]["readyReplicas"]) == int(


### PR DESCRIPTION
## Summary

The smoke-test ATS job worst-case runtime is dominated by the module-scoped `deployment` fixture being recreated on every flaky rerun. Each rerun pays the full readiness timeout, and the rerun budget is set to 5:

```
1 initial + 5 reruns = 6 attempts
6 × 560 s ≈ 56 min worst case
```

This PR:

- Cuts the per-attempt `timeout` from `560` → `180` (still ~3× the realistic ready time for the single-replica `klaus` Deployment in kind).
- Reduces `@pytest.mark.flaky(reruns=5, reruns_delay=10)` → `@pytest.mark.flaky(reruns=1, reruns_delay=15)`. One retry is enough for transient kube-API hiccups; `wait_for_deployments_to_run` is already a polling loop, so additional reruns don't shake anything loose.

Worst-case runtime drops from ~57 min to ~6 min while real failures still get a second chance.

This does **not** address why the deployment occasionally fails to become ready in CI — that's a separate issue.

Same fix as giantswarm/mcp-kubernetes#406; sibling PRs in `muster`, `mcp-prometheus`, and `dex-app`.

Made with [Cursor](https://cursor.com)