### PR TITLE
ci: migrate to architect-orb 8.1.0 multi-arch path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  architect: giantswarm/architect@8.0.2
+  architect: giantswarm/architect@8.1.0
 
 jobs:
   notify-downstream:
@@ -60,8 +60,9 @@ workflows:
             only: /^v.*/
 
     # Branch builds: amd64 only for faster PR feedback
-    - architect/push-to-registries-multiarch:
+    - architect/push-to-registries:
         context: architect
+        multiarch: true
         name: push-to-registries
         platforms: "linux/amd64"
         resource_class: medium
@@ -72,8 +73,9 @@ workflows:
             ignore:
             - main
 
-    - architect/push-to-registries-multiarch:
+    - architect/push-to-registries:
         context: architect
+        multiarch: true
         name: push-to-registries-debian
         image: giantswarm/klaus-debian
         dockerfile: ./Dockerfile.debian
@@ -87,8 +89,9 @@ workflows:
             - main
 
     # Branch builds: publish to klaus-toolchains namespace
-    - architect/push-to-registries-multiarch:
+    - architect/push-to-registries:
         context: architect
+        multiarch: true
         name: push-to-toolchains
         image: giantswarm/klaus-toolchains/base
         platforms: "linux/amd64"
@@ -100,8 +103,9 @@ workflows:
             ignore:
             - main
 
-    - architect/push-to-registries-multiarch:
+    - architect/push-to-registries:
         context: architect
+        multiarch: true
         name: push-to-toolchains-debian
         image: giantswarm/klaus-toolchains/base-debian
         dockerfile: ./Dockerfile.debian
@@ -115,8 +119,9 @@ workflows:
             - main
 
     # Main branch: tag images as :latest
-    - architect/push-to-registries-multiarch:
+    - architect/push-to-registries:
         context: architect
+        multiarch: true
         name: push-to-registries-latest
         tag-latest-branch: main
         requires:
@@ -125,8 +130,9 @@ workflows:
           branches:
             only: main
 
-    - architect/push-to-registries-multiarch:
+    - architect/push-to-registries:
         context: architect
+        multiarch: true
         name: push-to-registries-debian-latest
         image: giantswarm/klaus-debian
         dockerfile: ./Dockerfile.debian
@@ -137,8 +143,9 @@ workflows:
           branches:
             only: main
 
-    - architect/push-to-registries-multiarch:
+    - architect/push-to-registries:
         context: architect
+        multiarch: true
         name: push-to-toolchains-latest
         image: giantswarm/klaus-toolchains/base
         tag-latest-branch: main
@@ -148,8 +155,9 @@ workflows:
           branches:
             only: main
 
-    - architect/push-to-registries-multiarch:
+    - architect/push-to-registries:
         context: architect
+        multiarch: true
         name: push-to-toolchains-debian-latest
         image: giantswarm/klaus-toolchains/base-debian
         dockerfile: ./Dockerfile.debian
@@ -161,8 +169,9 @@ workflows:
             only: main
 
     # Tag builds: full multi-arch (amd64 + arm64)
-    - architect/push-to-registries-multiarch:
+    - architect/push-to-registries:
         context: architect
+        multiarch: true
         name: push-to-registries-release
         requires:
         - go-build-klaus
@@ -172,8 +181,9 @@ workflows:
           branches:
             ignore: /.*/
 
-    - architect/push-to-registries-multiarch:
+    - architect/push-to-registries:
         context: architect
+        multiarch: true
         name: push-to-registries-debian-release
         image: giantswarm/klaus-debian
         dockerfile: ./Dockerfile.debian
@@ -186,8 +196,9 @@ workflows:
             ignore: /.*/
 
     # Tag builds: publish to klaus-toolchains namespace
-    - architect/push-to-registries-multiarch:
+    - architect/push-to-registries:
         context: architect
+        multiarch: true
         name: push-to-toolchains-release
         image: giantswarm/klaus-toolchains/base
         requires:
@@ -198,8 +209,9 @@ workflows:
           branches:
             ignore: /.*/
 
-    - architect/push-to-registries-multiarch:
+    - architect/push-to-registries:
         context: architect
+        multiarch: true
         name: push-to-toolchains-debian-release
         image: giantswarm/klaus-toolchains/base-debian
         dockerfile: ./Dockerfile.debian

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `giantswarm/architect` orb to `8.1.0` and migrate all 12 image pushes from the deprecated `push-to-registries-multiarch` job to `push-to-registries` with `multiarch: true`. Picks up the v8.1.0 QEMU/binfmt auto-registration, hardened buildx bootstrap, and standard OCI image labels.
+
 ### Security
 
 - Bump Go to `1.26.3` (in `go.mod` and the `golang:` builder image in `Dockerfile`/`Dockerfile.debian`) and `golang.org/x/net` to `v0.53.0`, clearing four standard-library vulnerabilities (GO-2026-4971, GO-2026-4918, and two related entries affecting `net` / `net/http`) and two `golang.org/x/net` vulnerabilities flagged by `govulncheck` in CI.


### PR DESCRIPTION
## Summary

- Bump `giantswarm/architect` orb to `8.1.0`.
- Migrate all 12 `architect/push-to-registries-multiarch` invocations (branch, main `:latest`, and tag-release, each on klaus, klaus-debian, klaus-toolchains/base, klaus-toolchains/base-debian) to `architect/push-to-registries` with `multiarch: true`.

## Why

`push-to-registries-multiarch` was deprecated in orb v7.0.0 and will be removed in the next major version. Bumping to v8.1.0 picks up:

- Automatic QEMU/binfmt registration before `docker buildx build`.
- Hardened buildx builder bootstrap that surfaces failures instead of masking them.
- Standard OCI image labels and manifest-index annotations emitted by default.

## Test plan

- [x] Branch CI exercises the new `push-to-registries` (`multiarch: true`, `platforms: linux/amd64`) on this PR across all four images (klaus, klaus-debian, klaus-toolchains/base, klaus-toolchains/base-debian).
- [ ] Auto-release tag after merge exercises the full multi-arch (amd64+arm64) tag-build path, including the downstream dispatch to klaus-toolchains.

Made with [Cursor](https://cursor.com)