### PR TITLE
ci: enable split-china-push for the Aliyun mirror

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,11 +168,14 @@ workflows:
           branches:
             only: main
 
-    # Tag builds: full multi-arch (amd64 + arm64)
+    # Tag builds: full multi-arch (amd64 + arm64). split-china-push skips the
+    # Aliyun mirror on the buildx push; sync-china-registry jobs below mirror
+    # each image variant gsoci -> Aliyun via the in-China galaxy-runner.
     - architect/push-to-registries:
         context: architect
         multiarch: true
         name: push-to-registries-release
+        split-china-push: true
         requires:
         - go-build-klaus
         filters:
@@ -187,6 +190,7 @@ workflows:
         name: push-to-registries-debian-release
         image: giantswarm/klaus-debian
         dockerfile: ./Dockerfile.debian
+        split-china-push: true
         requires:
         - go-build-klaus
         filters:
@@ -201,6 +205,7 @@ workflows:
         multiarch: true
         name: push-to-toolchains-release
         image: giantswarm/klaus-toolchains/base
+        split-china-push: true
         requires:
         - go-build-klaus
         filters:
@@ -215,8 +220,59 @@ workflows:
         name: push-to-toolchains-debian-release
         image: giantswarm/klaus-toolchains/base-debian
         dockerfile: ./Dockerfile.debian
+        split-china-push: true
         requires:
         - go-build-klaus
+        filters:
+          tags:
+            only: /^v.*/
+          branches:
+            ignore: /.*/
+
+    # Mirror each image variant gsoci -> Aliyun via the in-China
+    # giantswarm/galaxy-runner. Runs in parallel with notify-downstream and
+    # the chart catalog push; an Aliyun mirror failure does NOT block them.
+    - architect/sync-china-registry:
+        context: architect
+        name: sync-china-registry-klaus
+        requires:
+        - push-to-registries-release
+        filters:
+          tags:
+            only: /^v.*/
+          branches:
+            ignore: /.*/
+
+    - architect/sync-china-registry:
+        context: architect
+        name: sync-china-registry-klaus-debian
+        image: giantswarm/klaus-debian
+        requires:
+        - push-to-registries-debian-release
+        filters:
+          tags:
+            only: /^v.*/
+          branches:
+            ignore: /.*/
+
+    - architect/sync-china-registry:
+        context: architect
+        name: sync-china-registry-toolchains-base
+        image: giantswarm/klaus-toolchains/base
+        requires:
+        - push-to-toolchains-release
+        filters:
+          tags:
+            only: /^v.*/
+          branches:
+            ignore: /.*/
+
+    - architect/sync-china-registry:
+        context: architect
+        name: sync-china-registry-toolchains-base-debian
+        image: giantswarm/klaus-toolchains/base-debian
+        requires:
+        - push-to-toolchains-debian-release
         filters:
           tags:
             only: /^v.*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Enable `split-china-push: true` on the four tag-build `push-to-registries-release` jobs (klaus, klaus-debian, klaus-toolchains/base, klaus-toolchains/base-debian) and add four companion `sync-china-registry` jobs. The cross-Pacific `docker buildx` push to the Aliyun mirror (which timed out for ~10 minutes per image and failed the tag job) is replaced with `regctl image copy` from gsoci to Aliyun executed on the in-China `giantswarm/galaxy-runner` self-hosted CircleCI runner. The chart-catalog publish and downstream notify chains no longer wait on Aliyun.
 - Bump `giantswarm/architect` orb to `8.1.0` and migrate all 12 image pushes from the deprecated `push-to-registries-multiarch` job to `push-to-registries` with `multiarch: true`. Picks up the v8.1.0 QEMU/binfmt auto-registration, hardened buildx bootstrap, and standard OCI image labels.
 
 ### Security


### PR DESCRIPTION
## Summary

- Add `split-china-push: true` to all four tag-build `push-to-registries-release` jobs (klaus, klaus-debian, klaus-toolchains/base, klaus-toolchains/base-debian).
- Add four companion `architect/sync-china-registry` jobs that mirror each image variant gsoci -> Aliyun on the in-China `giantswarm/galaxy-runner`.

## Why

After migrating to `architect@8.1.0` + `push-to-registries` (`multiarch: true`) in #260, tag builds (`v0.0.156`, `v0.0.157`) hit the long-standing Aliyun cross-Pacific `docker buildx` push timeout (~10 minutes per image) and failed several of the four release jobs even though the gsoci push had already succeeded with real multi-arch (amd64+arm64) manifests.

`split-china-push: true` (orb v7.1.0+) is the official fix: the main `push-to-registries` jobs push to gsoci/gsociprivate only, cache the source registry+tag, and per-image `sync-china-registry` jobs running on the `giantswarm/galaxy-runner` self-hosted CircleCI runner inside China use `regctl image copy` to mirror gsoci -> Aliyun (Singapore replica + 10x retries for eventual consistency).

The chart-catalog publish (`push-klaus-to-giantswarm-app-catalog-release`) and downstream notify (`notify-downstream`) chains still gate on the four `push-to-registries-release` jobs only -- they are not blocked by Aliyun. The four `sync-china-registry` jobs run in parallel and can fail/retry independently.

## Test plan

- [x] Branch CI exercises the unchanged amd64 `push-to-registries` jobs on this PR.
- [ ] Next `v*` tag exercises the new `split-china-push` + four `sync-china-registry` jobs end-to-end.


Made with [Cursor](https://cursor.com)