### PR TITLE
chore: add yamllint config relaxing line-length to 140

### DIFF
--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,11 @@
+---
+extends: default
+
+rules:
+  line-length:
+    max: 140
+  comments:
+    require-starting-space: true
+    min-spaces-from-content: 1
+  truthy:
+    check-keys: false


### PR DESCRIPTION
## Summary

The default yamllint 80-char limit blocks SHA-pinned action references for actions with longer names (e.g. `goreleaser/goreleaser-action`, `actions/setup-python`). Lines like

```
        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
```

are 92 chars and fail `make lint-yaml`, which in turn makes the SHA-pinning convention unworkable for several Renovate dependency PRs (#275, #278, #279).

This adds a project `.yamllint.yaml` that:
- raises `line-length` to 140
- relaxes `comments` to allow the single-space `# vX.Y.Z` Renovate produces
- disables `truthy` key-checking so `on:` keys don't trip the rule

## Test plan
- [x] CI's `Lint and Test` passes on workflow files