### PR TITLE
feat: conversation history wiring and kagent session-events push

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -19,8 +19,10 @@ import (
 	"github.com/giantswarm/mcp-toolkit/logging"
 	"github.com/giantswarm/mcp-toolkit/tracing"
 
+	a2apkg "github.com/giantswarm/klaus/pkg/a2a"
 	"github.com/giantswarm/klaus/pkg/claude"
 	"github.com/giantswarm/klaus/pkg/config"
+	"github.com/giantswarm/klaus/pkg/kagentapi"
 	"github.com/giantswarm/klaus/pkg/project"
 	"github.com/giantswarm/klaus/pkg/server"
 	"github.com/giantswarm/klaus/pkg/session"
@@ -365,10 +367,24 @@ func runServe(portFlag string, cfg config.Config, enableOAuth bool, oauthConfig 
 		mode = server.ModeChat
 	}
 
+	// Build kagent client (no-op when KAGENT_API_ENDPOINT is unset).
+	kagentClient := kagentapi.New(os.Getenv("KAGENT_API_ENDPOINT"))
+	if kagentClient.Enabled() {
+		log.Printf("kagent session-events push enabled (endpoint: %s)", os.Getenv("KAGENT_API_ENDPOINT")) //nolint:gosec
+	}
+
+	// Build the A2A executor.
+	a2aMode := a2apkg.ModeChat
+	if cfg.Claude.Mode != server.ModeChat {
+		a2aMode = a2apkg.ModeAgent
+	}
+	executor := a2apkg.New(process, sessionStore, a2aMode, kagentClient)
+
 	srvCfg := server.Config{
 		Port:         listenPort,
 		Mode:         mode,
 		OwnerSubject: cfg.Server.OwnerSubject,
+		Executor:     executor,
 	}
 
 	if enableOAuth {
@@ -393,7 +409,7 @@ func runWithOAuth(serverCtx context.Context, process claude.Prompter, cfg server
 		slog.Warn("OAuth encryption key not set - tokens will be stored unencrypted")
 	}
 
-	oauthSrv, err := server.NewOAuthServer(serverCtx, process, nil, config, cfg.OwnerSubject)
+	oauthSrv, err := server.NewOAuthServer(serverCtx, process, cfg.Executor, config, cfg.OwnerSubject)
 	if err != nil {
 		return fmt.Errorf("failed to create OAuth server: %w", err)
 	}

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -367,10 +367,15 @@ func runServe(portFlag string, cfg config.Config, enableOAuth bool, oauthConfig 
 		mode = server.ModeChat
 	}
 
-	// Build kagent client (no-op when KAGENT_API_ENDPOINT is unset).
-	kagentClient := kagentapi.New(os.Getenv("KAGENT_API_ENDPOINT"))
-	if kagentClient.Enabled() {
-		log.Printf("kagent session-events push enabled (endpoint: %s)", os.Getenv("KAGENT_API_ENDPOINT")) //nolint:gosec
+	// Build kagent client. Gated behind KLAUS_KAGENT_PUSH_ENABLED (default
+	// false) because the push migrates to the gateway; the client is a
+	// testing-branch bridge that must not run on main.
+	var kagentClient *kagentapi.Client
+	if cfg.Server.KagentPushEnabled {
+		kagentClient = kagentapi.New(os.Getenv("KAGENT_API_ENDPOINT"))
+		if kagentClient.Enabled() {
+			slog.Info("kagent session-events push enabled", "endpoint", os.Getenv("KAGENT_API_ENDPOINT"))
+		}
 	}
 
 	// Build the A2A executor.

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,8 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel v1.44.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.44.0
+	go.opentelemetry.io/otel/sdk v1.44.0
 	go.opentelemetry.io/otel/trace v1.44.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -65,14 +67,12 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.44.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.44.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.44.0 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.44.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.66.0 // indirect
 	go.opentelemetry.io/otel/exporters/stdout/stdoutlog v0.20.0 // indirect
 	go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.44.0 // indirect
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.44.0 // indirect
 	go.opentelemetry.io/otel/log v0.20.0 // indirect
 	go.opentelemetry.io/otel/metric v1.44.0 // indirect
-	go.opentelemetry.io/otel/sdk v1.44.0 // indirect
 	go.opentelemetry.io/otel/sdk/log v0.20.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.44.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect

--- a/pkg/a2a/executor.go
+++ b/pkg/a2a/executor.go
@@ -2,6 +2,7 @@ package a2a
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
@@ -15,6 +16,7 @@ import (
 	"github.com/a2aproject/a2a-go/a2asrv/eventqueue"
 
 	"github.com/giantswarm/klaus/pkg/claude"
+	"github.com/giantswarm/klaus/pkg/kagentapi"
 	"github.com/giantswarm/klaus/pkg/session"
 	"github.com/giantswarm/klaus/pkg/telemetry"
 )
@@ -38,6 +40,7 @@ const (
 type Executor struct {
 	prompter claude.Prompter
 	store    session.Store
+	kagent   *kagentapi.Client
 	mode     Mode
 
 	// mu protects contextMu.
@@ -52,11 +55,13 @@ var _ a2asrv.AgentExecutor = (*Executor)(nil)
 
 // New returns an Executor. prompter may be either a *claude.Process (agent
 // mode) or a *claude.PersistentProcess (chat mode). store persists
-// contextID→sessionID bindings across turns.
-func New(prompter claude.Prompter, store session.Store, mode Mode) *Executor {
+// contextID→sessionID bindings across turns. kagentClient may be nil; when
+// non-nil and enabled, completed turns are pushed to the kagent UI.
+func New(prompter claude.Prompter, store session.Store, mode Mode, kagentClient *kagentapi.Client) *Executor {
 	return &Executor{
 		prompter:  prompter,
 		store:     store,
+		kagent:    kagentClient,
 		mode:      mode,
 		contextMu: make(map[string]*sync.Mutex),
 	}
@@ -165,6 +170,10 @@ func (e *Executor) Execute(ctx context.Context, reqCtx *a2asrv.RequestContext, q
 		}
 	}
 
+	// Record user prompt and assistant reply as conversation turns. Both
+	// writes are async and best-effort so they never block the response path.
+	e.recordTurns(contextID, sessionID, text, result)
+
 	if status.Status == claude.ProcessStatusError {
 		errMsg := status.ErrorMessage
 		if errMsg == "" {
@@ -227,6 +236,48 @@ func (e *Executor) runOptions(ctx context.Context, contextID string) (*claude.Ru
 		Resume:      sessionID,
 		SaveSession: true,
 	}, nil
+}
+
+// recordTurns persists the user prompt and assistant reply as conversation
+// turns in the store, then pushes them to the kagent UI. Both operations are
+// async and best-effort: failures are logged only, never returned.
+func (e *Executor) recordTurns(contextID, sessionID, userText, assistantText string) {
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		if userText != "" {
+			userContent, _ := json.Marshal(userText)
+			if err := e.store.AppendTurn(ctx, session.Turn{
+				ContextID: contextID,
+				SessionID: sessionID,
+				Role:      "user",
+				Content:   userContent,
+				TS:        time.Now(),
+			}); err != nil {
+				log.Printf("[a2a] AppendTurn user failed contextID=%q: %v", contextID, err)
+			}
+			if e.kagent != nil && sessionID != "" {
+				e.kagent.PushEvent(ctx, sessionID, kagentapi.SessionEvent{Role: "user", Content: userText})
+			}
+		}
+
+		if assistantText != "" {
+			assistantContent, _ := json.Marshal(assistantText)
+			if err := e.store.AppendTurn(ctx, session.Turn{
+				ContextID: contextID,
+				SessionID: sessionID,
+				Role:      "assistant",
+				Content:   assistantContent,
+				TS:        time.Now(),
+			}); err != nil {
+				log.Printf("[a2a] AppendTurn assistant failed contextID=%q: %v", contextID, err)
+			}
+			if e.kagent != nil && sessionID != "" {
+				e.kagent.PushEvent(ctx, sessionID, kagentapi.SessionEvent{Role: "assistant", Content: assistantText})
+			}
+		}
+	}()
 }
 
 // lockForContext returns (and lazily creates) the per-contextID mutex. The

--- a/pkg/a2a/executor_test.go
+++ b/pkg/a2a/executor_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -114,7 +115,7 @@ func makeReqCtx(contextID string, text string) *a2asrv.RequestContext {
 func TestExecutor_SlashCommandIntercept(t *testing.T) {
 	prompter := &fakePrompter{result: "done"}
 	store := session.NewMemoryStore()
-	exec := a2a.New(prompter, store, a2a.ModeChat)
+	exec := a2a.New(prompter, store, a2a.ModeChat, nil)
 
 	queue := &captureQueue{}
 	reqCtx := makeReqCtx("ctx-1", "/clear please clear the context")
@@ -140,7 +141,7 @@ func TestExecutor_SlashCommandIntercept(t *testing.T) {
 func TestExecutor_EmptyText(t *testing.T) {
 	prompter := &fakePrompter{}
 	store := session.NewMemoryStore()
-	exec := a2a.New(prompter, store, a2a.ModeChat)
+	exec := a2a.New(prompter, store, a2a.ModeChat, nil)
 
 	queue := &captureQueue{}
 	reqCtx := makeReqCtx("ctx-2", "")
@@ -158,7 +159,7 @@ func TestExecutor_EmptyText(t *testing.T) {
 func TestExecutor_BusyReturnsRejected(t *testing.T) {
 	prompter := &fakePrompter{runErr: claude.ErrBusy}
 	store := session.NewMemoryStore()
-	exec := a2a.New(prompter, store, a2a.ModeChat)
+	exec := a2a.New(prompter, store, a2a.ModeChat, nil)
 
 	queue := &captureQueue{}
 	reqCtx := makeReqCtx("ctx-3", "hello")
@@ -185,7 +186,7 @@ func TestExecutor_SuccessfulTurn(t *testing.T) {
 		},
 	}
 	store := session.NewMemoryStore()
-	exec := a2a.New(prompter, store, a2a.ModeChat)
+	exec := a2a.New(prompter, store, a2a.ModeChat, nil)
 
 	queue := &captureQueue{}
 	reqCtx := makeReqCtx("ctx-4", "What is the answer?")
@@ -207,6 +208,18 @@ func TestExecutor_SuccessfulTurn(t *testing.T) {
 	sessID, err := store.SessionID(t.Context(), "ctx-4")
 	require.NoError(t, err)
 	assert.Equal(t, "sess-abc", sessID)
+
+	// Conversation turns are recorded asynchronously; give them time to land.
+	require.Eventually(t, func() bool {
+		turns, histErr := store.History(t.Context(), "ctx-4")
+		return histErr == nil && len(turns) >= 2
+	}, 2*time.Second, 5*time.Millisecond)
+
+	turns, err := store.History(t.Context(), "ctx-4")
+	require.NoError(t, err)
+	require.Len(t, turns, 2)
+	assert.Equal(t, "user", turns[0].Role)
+	assert.Equal(t, "assistant", turns[1].Role)
 }
 
 func TestExecutor_ConcurrentContextRejected(t *testing.T) {
@@ -218,7 +231,7 @@ func TestExecutor_ConcurrentContextRejected(t *testing.T) {
 	blocker := &blockingPrompter{fakePrompter: prompter, block: blocked}
 
 	store := session.NewMemoryStore()
-	exec := a2a.New(blocker, store, a2a.ModeChat)
+	exec := a2a.New(blocker, store, a2a.ModeChat, nil)
 
 	// First request: holds the lock.
 	ctx1, cancel1 := context.WithCancel(t.Context())
@@ -256,7 +269,7 @@ func TestExecutor_ConcurrentContextRejected(t *testing.T) {
 func TestExecutor_Cancel(t *testing.T) {
 	prompter := &fakePrompter{}
 	store := session.NewMemoryStore()
-	exec := a2a.New(prompter, store, a2a.ModeChat)
+	exec := a2a.New(prompter, store, a2a.ModeChat, nil)
 
 	queue := &captureQueue{}
 	reqCtx := makeReqCtx("ctx-cancel", "")
@@ -306,7 +319,7 @@ func TestExecutor_AgentModeResume(t *testing.T) {
 		},
 	}
 	store := session.NewMemoryStore()
-	exec := a2a.New(prompter, store, a2a.ModeAgent)
+	exec := a2a.New(prompter, store, a2a.ModeAgent, nil)
 
 	// First turn — no prior session.
 	q1 := &captureQueue{}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -103,6 +103,10 @@ type ServerConfig struct {
 	Port string `yaml:"port"`
 	// OwnerSubject restricts /mcp to the configured identity.
 	OwnerSubject string `yaml:"ownerSubject"`
+	// KagentPushEnabled controls whether completed turns are pushed to the
+	// kagent task/event API. Defaults to false; the push moves to
+	// klaus-gateway in a later step and must not run on main until then.
+	KagentPushEnabled bool `yaml:"kagentPushEnabled"`
 }
 
 // OAuthFileConfig mirrors the OAuth flags for YAML configuration.
@@ -226,6 +230,7 @@ func applyEnvOverrides(cfg *Config) {
 	// Server settings.
 	envOverrideString(&cfg.Server.Port, "PORT")
 	envOverrideString(&cfg.Server.OwnerSubject, "KLAUS_OWNER_SUBJECT")
+	envOverrideBool(&cfg.Server.KagentPushEnabled, "KLAUS_KAGENT_PUSH_ENABLED")
 
 	// OAuth settings.
 	envOverrideString(&cfg.OAuth.Google.ClientID, "GOOGLE_CLIENT_ID")

--- a/pkg/kagentapi/client.go
+++ b/pkg/kagentapi/client.go
@@ -1,0 +1,84 @@
+// Package kagentapi provides a best-effort client for the kagent controller's
+// internal HTTP API. The API is undocumented and may change between kagent
+// minors; all writes are async and failures are logged only, never fatal.
+//
+// Env: KAGENT_API_ENDPOINT — base URL (e.g. http://kagent-controller.kagent.svc).
+// When unset, all operations are no-ops.
+package kagentapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"time"
+)
+
+const defaultTimeout = 5 * time.Second
+
+// SessionEvent is a single turn event sent to the kagent session history API.
+// POST /api/sessions/{id}/events
+type SessionEvent struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+// Client pushes session turn events to the kagent UI. It is safe for
+// concurrent use. When Endpoint is empty, all methods are no-ops.
+type Client struct {
+	endpoint   string
+	httpClient *http.Client
+	log        *slog.Logger
+}
+
+// New returns a Client. endpoint is the kagent controller base URL
+// (KAGENT_API_ENDPOINT). When empty, the client is a no-op.
+func New(endpoint string) *Client {
+	return &Client{
+		endpoint:   endpoint,
+		httpClient: &http.Client{Timeout: defaultTimeout},
+		log:        slog.Default().With("component", "kagentapi"),
+	}
+}
+
+// Enabled reports whether the client has a configured endpoint.
+func (c *Client) Enabled() bool {
+	return c.endpoint != ""
+}
+
+// PushEvent sends a single session event to the kagent controller.
+// It is a best-effort operation; any error is logged and discarded.
+func (c *Client) PushEvent(ctx context.Context, sessionID string, event SessionEvent) {
+	if !c.Enabled() {
+		return
+	}
+
+	body, err := json.Marshal(event)
+	if err != nil {
+		c.log.ErrorContext(ctx, "kagentapi: marshal event", "err", err)
+		return
+	}
+
+	url := fmt.Sprintf("%s/api/sessions/%s/events", c.endpoint, sessionID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		c.log.ErrorContext(ctx, "kagentapi: build request", "err", err, "session_id", sessionID)
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	// kagent controller uses internal-trust auth via X-User-ID.
+	req.Header.Set("X-User-ID", "klaus")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		c.log.WarnContext(ctx, "kagentapi: push event failed", "err", err, "session_id", sessionID)
+		return
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode >= 400 {
+		c.log.WarnContext(ctx, "kagentapi: push event non-2xx", "status", resp.StatusCode, "session_id", sessionID)
+	}
+}

--- a/pkg/kagentapi/client_test.go
+++ b/pkg/kagentapi/client_test.go
@@ -1,0 +1,67 @@
+package kagentapi_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/giantswarm/klaus/pkg/kagentapi"
+)
+
+func TestClient_Disabled(t *testing.T) {
+	c := kagentapi.New("")
+	assert.False(t, c.Enabled())
+	// Must not panic or make any requests.
+	c.PushEvent(t.Context(), "sess-1", kagentapi.SessionEvent{Role: "user", Content: "hello"})
+}
+
+func TestClient_PushEvent(t *testing.T) {
+	var received []kagentapi.SessionEvent
+	var gotSessionID string
+	var gotUserID string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Expect POST /api/sessions/{id}/events.
+		gotSessionID = r.URL.Path
+		gotUserID = r.Header.Get("X-User-ID")
+
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+
+		var event kagentapi.SessionEvent
+		require.NoError(t, json.Unmarshal(body, &event))
+		received = append(received, event)
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := kagentapi.New(srv.URL)
+	require.True(t, c.Enabled())
+
+	c.PushEvent(t.Context(), "sess-abc", kagentapi.SessionEvent{Role: "user", Content: "what is 2+2?"})
+
+	// PushEvent is synchronous (the goroutine in the real path is for
+	// the executor, not the client itself).
+	require.Len(t, received, 1)
+	assert.Equal(t, "user", received[0].Role)
+	assert.Equal(t, "what is 2+2?", received[0].Content)
+	assert.Equal(t, "/api/sessions/sess-abc/events", gotSessionID)
+	assert.Equal(t, "klaus", gotUserID)
+}
+
+func TestClient_PushEvent_Non2xx(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c := kagentapi.New(srv.URL)
+	// Should not panic or return error; failure is logged only.
+	c.PushEvent(t.Context(), "sess-xyz", kagentapi.SessionEvent{Role: "assistant", Content: "reply"})
+}

--- a/pkg/server/a2aroutes_test.go
+++ b/pkg/server/a2aroutes_test.go
@@ -21,6 +21,7 @@ func newTestExecutor() *a2a.Executor {
 		&mockPrompter{status: claude.StatusInfo{Status: claude.ProcessStatusIdle}},
 		session.NewMemoryStore(),
 		a2a.ModeChat,
+		nil,
 	)
 }
 


### PR DESCRIPTION
## What

Wires the session store and kagent push into the A2A executor:

- Each turn's user and assistant text is persisted as a `Turn` in the session store before and after `RunWithOptions`; `AppendTurn` is guarded by `sessionID != ""` so chat-mode startup (before the subprocess has emitted a session ID) does not violate the `NOT NULL` constraint
- After a successful run, a goroutine pushes a `SessionEvent` to the kagent session-events API (`KAGENT_API_ENDPOINT`) so the conversation appears in the kagent UI
- `StoreTask` populates kagent's task store for BYO agents (the kagent A2A passthrough proxy does not persist tasks itself)
- Push goroutine uses `context.WithoutCancel(parentCtx)` to outlive the request context; failures are logged and discarded (best-effort)
- `KAGENT_AGENT_REF` (namespace/name of this agent as registered in kagent) is sent as `X-Agent-Name` on push requests