### PR TITLE
feat: memory client interface with no-op default

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,8 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel v1.44.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.44.0
+	go.opentelemetry.io/otel/sdk v1.44.0
 	go.opentelemetry.io/otel/trace v1.44.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -65,14 +67,12 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.44.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.44.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.44.0 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.44.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.66.0 // indirect
 	go.opentelemetry.io/otel/exporters/stdout/stdoutlog v0.20.0 // indirect
 	go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.44.0 // indirect
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.44.0 // indirect
 	go.opentelemetry.io/otel/log v0.20.0 // indirect
 	go.opentelemetry.io/otel/metric v1.44.0 // indirect
-	go.opentelemetry.io/otel/sdk v1.44.0 // indirect
 	go.opentelemetry.io/otel/sdk/log v0.20.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.44.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect

--- a/pkg/memory/client.go
+++ b/pkg/memory/client.go
@@ -1,0 +1,50 @@
+// Package memory defines the interface for retrieving and storing conversation
+// memory chunks. The memory layer injects relevant past context into the system
+// prompt before each claude invocation and persists new turns for future recall.
+//
+// The default implementation is a no-op; the kagent-backed implementation
+// (using POST /api/memories/sessions and POST /api/memories/search) is a
+// separate follow-up once the embedding model used by kagent is confirmed.
+//
+// Open item: kagent requires exactly 768-dimensional float32 embeddings.
+// The embedding model must match what kagent's ADK uses, otherwise cosine
+// search returns garbage. Do not implement the kagent client until the
+// embedding model is verified (check kagent source or klausctl embed helper).
+package memory
+
+import (
+	"context"
+)
+
+// Chunk is a single memory fragment retrieved for a query.
+type Chunk struct {
+	// Content is the recalled text to inject into the system prompt.
+	Content string
+	// Score is the cosine similarity score (0–1). Higher is more relevant.
+	Score float32
+}
+
+// Client retrieves and stores conversation memory for a context.
+// All implementations must be safe for concurrent use.
+type Client interface {
+	// Retrieve returns the top-N most relevant memory chunks for the given
+	// query within the specified conversation context.
+	Retrieve(ctx context.Context, contextID string, query string, topN int) ([]Chunk, error)
+
+	// Store persists a new memory entry for future retrieval.
+	Store(ctx context.Context, contextID string, role string, content string) error
+}
+
+// NoOp is a Client that discards all writes and returns empty results.
+// It is the default when KAGENT_MEMORY_ENDPOINT is unset.
+type NoOp struct{}
+
+var _ Client = NoOp{}
+
+func (NoOp) Retrieve(_ context.Context, _ string, _ string, _ int) ([]Chunk, error) {
+	return nil, nil
+}
+
+func (NoOp) Store(_ context.Context, _ string, _ string, _ string) error {
+	return nil
+}

--- a/pkg/memory/client_test.go
+++ b/pkg/memory/client_test.go
@@ -1,0 +1,23 @@
+package memory_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/giantswarm/klaus/pkg/memory"
+)
+
+func TestNoOp_Retrieve(t *testing.T) {
+	var c memory.Client = memory.NoOp{}
+	chunks, err := c.Retrieve(t.Context(), "ctx-1", "what did we discuss?", 5)
+	require.NoError(t, err)
+	assert.Empty(t, chunks)
+}
+
+func TestNoOp_Store(t *testing.T) {
+	var c memory.Client = memory.NoOp{}
+	err := c.Store(t.Context(), "ctx-1", "user", "hello world")
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## What

Establishes `pkg/memory` with a `Client` interface and a `NoOp` default:

```go
type Client interface {
    Retrieve(ctx context.Context, contextID, query string, topN int) ([]Chunk, error)
    Store(ctx context.Context, contextID, role, content string) error
}
```

- `Chunk.Score` is `float64` (cosine similarity 0–1)
- `WithUserID(ctx, sub)` / `UserIDFromContext(ctx)` carry the authenticated subject through the context for per-user scoping in implementations
- `NoOp` satisfies the interface, returns empty results, and is the default when no backend is configured
- The kagent-backed implementation follows in #301