### PR TITLE
feat(memory): kagent-backed memory client with OpenAI-compatible embeddings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,11 @@ RUN VERSION=${VERSION:-$(git describe --tags --always --dirty 2>/dev/null || ech
     -X 'main.date=${DATE}'" \
     -o klaus .
 
-# Stage 2: Minimal runtime with Node.js and Claude CLI.
+# Stage 2: Go toolchain for the target platform.
+# Keep the version in sync with the builder stage above.
+FROM golang:1.26.4-alpine AS go-toolchain
+
+# Stage 3: Minimal runtime with Node.js, Claude CLI, and Go toolchain.
 FROM node:24-${VARIANT}
 ARG VARIANT
 
@@ -60,6 +64,9 @@ RUN mkdir -p /workspace && chown klaus:klaus /workspace
 # Copy the Go binary from the builder stage.
 COPY --from=builder /app/klaus /usr/local/bin/klaus
 
+# Copy the Go toolchain so Claude Code can compile and run Go programs.
+COPY --from=go-toolchain /usr/local/go /usr/local/go
+
 LABEL io.giantswarm.klaus.type=toolchain \
       io.giantswarm.klaus.name=klaus
 USER klaus
@@ -67,6 +74,9 @@ WORKDIR /workspace
 
 ENV PORT=8080
 ENV SHELL=/bin/bash
+ENV GOROOT=/usr/local/go
+ENV GOPATH=/workspace/go
+ENV PATH="/usr/local/go/bin:${PATH}"
 EXPOSE 8080
 
 ENTRYPOINT ["klaus"]

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -30,7 +30,11 @@ RUN VERSION=${VERSION:-$(git describe --tags --always --dirty 2>/dev/null || ech
     -X 'main.date=${DATE}'" \
     -o klaus .
 
-# Stage 2: Minimal runtime with Node.js and Claude CLI.
+# Stage 2: Go toolchain for the target platform.
+# Keep the version in sync with the builder stage above.
+FROM golang:1.26.4 AS go-toolchain
+
+# Stage 3: Minimal runtime with Node.js, Claude CLI, and Go toolchain.
 FROM node:24-${VARIANT}
 ARG VARIANT
 
@@ -64,6 +68,9 @@ RUN mkdir -p /workspace && chown klaus:klaus /workspace
 # Copy the Go binary from the builder stage.
 COPY --from=builder /app/klaus /usr/local/bin/klaus
 
+# Copy the Go toolchain so Claude Code can compile and run Go programs.
+COPY --from=go-toolchain /usr/local/go /usr/local/go
+
 LABEL io.giantswarm.klaus.type=toolchain \
       io.giantswarm.klaus.name=klaus
 USER klaus
@@ -71,6 +78,9 @@ WORKDIR /workspace
 
 ENV PORT=8080
 ENV SHELL=/bin/bash
+ENV GOROOT=/usr/local/go
+ENV GOPATH=/workspace/go
+ENV PATH="/usr/local/go/bin:${PATH}"
 EXPOSE 8080
 
 ENTRYPOINT ["klaus"]

--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -26,9 +26,12 @@ docker-build-debian: ## Build Debian Docker image
 	@echo "Building Debian image..."
 	@docker build -f Dockerfile.debian -t klaus:debian .
 
-generate-dockerfile-debian: ## Regenerate Dockerfile.debian from Dockerfile (only VARIANT default differs)
+generate-dockerfile-debian: ## Regenerate Dockerfile.debian from Dockerfile (only VARIANT default and go-toolchain image differ)
 	@printf '# DO NOT EDIT. Generated from Dockerfile.\n# This file exists so the CI job can build the Debian variant without --build-arg.\n# Regenerate with: make generate-dockerfile-debian\n\n' > Dockerfile.debian
-	@sed 's/^ARG VARIANT=alpine$$/ARG VARIANT=slim/' Dockerfile >> Dockerfile.debian
+	@sed \
+		-e 's/^ARG VARIANT=alpine$$/ARG VARIANT=slim/' \
+		-e 's/FROM golang:\([^ ]*\)-alpine AS go-toolchain/FROM golang:\1 AS go-toolchain/' \
+		Dockerfile >> Dockerfile.debian
 
 ##@ Development
 

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -299,6 +299,16 @@ func runServe(portFlag string, cfg config.Config, enableOAuth bool, oauthConfig 
 	if cfg.Claude.ActiveAgent != "" {
 		opts.ActiveAgent = cfg.Claude.ActiveAgent
 	}
+	if cfg.Claude.RetryMaxAttempts > 0 {
+		opts.RetryMaxAttempts = cfg.Claude.RetryMaxAttempts
+	}
+	if cfg.Claude.RetryBaseBackoff != "" {
+		if d, parseErr := time.ParseDuration(cfg.Claude.RetryBaseBackoff); parseErr == nil {
+			opts.RetryBaseBackoff = d
+		} else {
+			log.Printf("WARNING: ignoring invalid KLAUS_RETRY_BASE_BACKOFF %q: %v", cfg.Claude.RetryBaseBackoff, parseErr)
+		}
+	}
 	// Derive NoSessionPersistence from mode: agent -> true, chat -> false.
 	// DefaultOptions() already sets NoSessionPersistence=true (agent default),
 	// so only override for chat mode.

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -411,7 +411,7 @@ func runServe(portFlag string, cfg config.Config, enableOAuth bool, oauthConfig 
 	}
 
 	// Build memory client. No-op when KAGENT_MEMORY_ENDPOINT or
-	// KLAUD_EMBEDDING_MODEL is unset.
+	// KLAUS_EMBEDDING_MODEL is unset.
 	memClient := memory.New()
 	if _, ok := memClient.(memory.NoOp); !ok {
 		slog.Info("memory augmentation enabled", "endpoint", os.Getenv("KAGENT_MEMORY_ENDPOINT"))

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -332,7 +332,7 @@ func runServe(portFlag string, cfg config.Config, enableOAuth bool, oauthConfig 
 		slog.Warn("KLAUS_SOUL_FILE set but file does not exist or is empty", "path", soulPath)
 	}
 
-	// Build the session store. Uses Postgres when KLAUS_PG_DSN is set,
+	// Build the session store. Uses Postgres when KLAUS_PGSQL_DSN is set,
 	// otherwise falls back to a local file store under ~/.klaus/sessions.
 	sessionStore, err := session.NewStore(context.Background())
 	if err != nil {

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -23,6 +23,7 @@ import (
 	"github.com/giantswarm/klaus/pkg/claude"
 	"github.com/giantswarm/klaus/pkg/config"
 	"github.com/giantswarm/klaus/pkg/kagentapi"
+	"github.com/giantswarm/klaus/pkg/memory"
 	"github.com/giantswarm/klaus/pkg/project"
 	"github.com/giantswarm/klaus/pkg/server"
 	"github.com/giantswarm/klaus/pkg/session"
@@ -336,6 +337,27 @@ func runServe(portFlag string, cfg config.Config, enableOAuth bool, oauthConfig 
 	}
 	slog.Info("session store ready", "type", fmt.Sprintf("%T", sessionStore), "backend", os.Getenv("KLAUS_RESULT_BACKEND"))
 
+	// Seed the session store when CLAUDE_CONTEXT_ID and CLAUDE_SESSION_ID are
+	// set. This lets an operator pre-bind a context → session mapping at pod
+	// start, enabling agent-mode resume across restarts without a first-turn
+	// warm-up call. For chat mode the ResumeSessionID option handles this.
+	seedContextID := os.Getenv("CLAUDE_CONTEXT_ID")
+	seedSessionID := os.Getenv("CLAUDE_SESSION_ID")
+	if seedContextID != "" && seedSessionID != "" {
+		if bindErr := sessionStore.BindSession(context.Background(), seedContextID, seedSessionID); bindErr != nil {
+			log.Printf("WARNING: failed to seed session store (context=%s session=%s): %v", seedContextID, seedSessionID, bindErr) //nolint:gosec
+		} else {
+			log.Printf("Pre-seeded session store: context=%s session=%s", seedContextID, seedSessionID) //nolint:gosec
+		}
+	}
+
+	// In chat mode, propagate CLAUDE_SESSION_ID as the startup resume session
+	// so the persistent subprocess continues an existing conversation after a
+	// pod restart. In agent mode the store binding (above) handles this.
+	if cfg.Claude.Mode == server.ModeChat && seedSessionID != "" {
+		opts.ResumeSessionID = seedSessionID
+	}
+
 	// Create the Claude process manager.
 	// Note: permissionMode and effort are already validated by cfg.Validate()
 	// using the canonical validators from the claude package.
@@ -378,12 +400,19 @@ func runServe(portFlag string, cfg config.Config, enableOAuth bool, oauthConfig 
 		}
 	}
 
+	// Build memory client. No-op when KAGENT_MEMORY_ENDPOINT or
+	// KLAUD_EMBEDDING_MODEL is unset.
+	memClient := memory.New()
+	if _, ok := memClient.(memory.NoOp); !ok {
+		log.Printf("memory augmentation enabled (kagent endpoint: %s)", os.Getenv("KAGENT_MEMORY_ENDPOINT")) //nolint:gosec
+	}
+
 	// Build the A2A executor.
 	a2aMode := a2apkg.ModeChat
 	if cfg.Claude.Mode != server.ModeChat {
 		a2aMode = a2apkg.ModeAgent
 	}
-	executor := a2apkg.New(process, sessionStore, a2aMode, kagentClient)
+	executor := a2apkg.New(process, sessionStore, a2aMode, kagentClient, memClient)
 
 	srvCfg := server.Config{
 		Port:         listenPort,

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -306,7 +306,7 @@ func runServe(portFlag string, cfg config.Config, enableOAuth bool, oauthConfig 
 		if d, parseErr := time.ParseDuration(cfg.Claude.RetryBaseBackoff); parseErr == nil {
 			opts.RetryBaseBackoff = d
 		} else {
-			log.Printf("WARNING: ignoring invalid KLAUS_RETRY_BASE_BACKOFF %q: %v", cfg.Claude.RetryBaseBackoff, parseErr)
+			slog.Warn("ignoring invalid KLAUS_RETRY_BASE_BACKOFF", "value", cfg.Claude.RetryBaseBackoff, "error", parseErr)
 		}
 	}
 	// Derive NoSessionPersistence from mode: agent -> true, chat -> false.
@@ -332,8 +332,8 @@ func runServe(portFlag string, cfg config.Config, enableOAuth bool, oauthConfig 
 		slog.Warn("KLAUS_SOUL_FILE set but file does not exist or is empty", "path", soulPath)
 	}
 
-	// Build the session store. Defaults to local backend; Postgres is used when
-	// KLAUS_RESULT_BACKEND=postgres and KLAUS_PG_DSN is set.
+	// Build the session store. Uses Postgres when KLAUS_PG_DSN is set,
+	// otherwise falls back to a local file store under ~/.klaus/sessions.
 	sessionStore, err := session.NewStore(context.Background())
 	if err != nil {
 		return fmt.Errorf("initialising session store: %w", err)
@@ -345,7 +345,7 @@ func runServe(portFlag string, cfg config.Config, enableOAuth bool, oauthConfig 
 			}
 		}()
 	}
-	slog.Info("session store ready", "type", fmt.Sprintf("%T", sessionStore), "backend", os.Getenv("KLAUS_RESULT_BACKEND"))
+	slog.Info("session store ready", "type", fmt.Sprintf("%T", sessionStore))
 
 	// Seed the session store when CLAUDE_CONTEXT_ID and CLAUDE_SESSION_ID are
 	// set. This lets an operator pre-bind a context → session mapping at pod
@@ -355,9 +355,9 @@ func runServe(portFlag string, cfg config.Config, enableOAuth bool, oauthConfig 
 	seedSessionID := os.Getenv("CLAUDE_SESSION_ID")
 	if seedContextID != "" && seedSessionID != "" {
 		if bindErr := sessionStore.BindSession(context.Background(), seedContextID, seedSessionID); bindErr != nil {
-			log.Printf("WARNING: failed to seed session store (context=%s session=%s): %v", seedContextID, seedSessionID, bindErr) //nolint:gosec
+			slog.Error("failed to seed session store", "context_id", seedContextID, "session_id", seedSessionID, "error", bindErr)
 		} else {
-			log.Printf("Pre-seeded session store: context=%s session=%s", seedContextID, seedSessionID) //nolint:gosec
+			slog.Info("pre-seeded session store", "context_id", seedContextID, "session_id", seedSessionID)
 		}
 	}
 
@@ -414,7 +414,7 @@ func runServe(portFlag string, cfg config.Config, enableOAuth bool, oauthConfig 
 	// KLAUD_EMBEDDING_MODEL is unset.
 	memClient := memory.New()
 	if _, ok := memClient.(memory.NoOp); !ok {
-		log.Printf("memory augmentation enabled (kagent endpoint: %s)", os.Getenv("KAGENT_MEMORY_ENDPOINT")) //nolint:gosec
+		slog.Info("memory augmentation enabled", "endpoint", os.Getenv("KAGENT_MEMORY_ENDPOINT"))
 	}
 
 	// Build the A2A executor.

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -63,6 +63,50 @@ All klaus configuration is done via environment variables. Only `ANTHROPIC_API_K
 | `CLAUDE_SETTING_SOURCES` | Setting sources to load (comma-separated) | -- |
 | `CLAUDE_PLUGIN_DIRS` | Plugin directories (comma-separated) | -- |
 
+## Subprocess retry
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `KLAUS_RETRY_MAX_ATTEMPTS` | Maximum subprocess restart attempts by the watchdog | `3` |
+| `KLAUS_RETRY_BASE_BACKOFF` | Initial backoff before first restart (e.g. `2s`); doubles each attempt | `2s` |
+
+## Session store
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `KLAUS_RESULT_BACKEND` | Session backend: `local`, `postgres`, or `memory` | `local` |
+| `KLAUS_PG_DSN` | PostgreSQL DSN; required when `KLAUS_RESULT_BACKEND=postgres` | -- |
+| `KLAUS_SESSION_DIR` | Override directory for the local backend | -- |
+| `CLAUDE_CONTEXT_ID` | Pre-seed context ID at startup | -- |
+| `CLAUDE_SESSION_ID` | Pre-seed session ID at startup; also passed as `--resume` in chat mode | -- |
+
+## kagent
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `KAGENT_API_ENDPOINT` | kagent controller base URL; enables A2A turn push to the kagent UI | -- |
+
+## Memory augmentation
+
+Requires `KAGENT_MEMORY_ENDPOINT` and `KLAUD_EMBEDDING_MODEL` to be set. When either is absent, memory is silently disabled.
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `KAGENT_MEMORY_ENDPOINT` | kagent controller base URL for memory storage/retrieval | -- |
+| `KAGENT_MEMORY_AGENT_NAME` | Agent identifier for memory attribution | `klaus` |
+| `KAGENT_MEMORY_USER_ID` | User identifier for memory attribution | `default` |
+| `KLAUD_EMBEDDING_ENDPOINT` | OpenAI-compatible embedding base URL | `https://api.openai.com/v1` |
+| `KLAUD_EMBEDDING_MODEL` | Embedding model name (e.g. `text-embedding-3-small`); required to enable memory | -- |
+| `KLAUD_EMBEDDING_API_KEY` | API key for the embedding endpoint; omit for unauthenticated endpoints | -- |
+
+## OTel tracing (server-side)
+
+Klaus exports its own traces (A2A task lifecycle, subprocess restarts) when `OTEL_EXPORTER_OTLP_ENDPOINT` is set. The Claude Code subprocess has its own OTel env vars (see [Telemetry](../telemetry.md)).
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP exporter endpoint; leave unset to disable | -- |
+
 ## Server
 
 | Variable | Description | Default |
@@ -79,3 +123,4 @@ The following variables are validated at startup:
 - `CLAUDE_PERMISSION_MODE` must be a valid mode
 - `CLAUDE_MAX_TURNS` must be >= 0
 - `CLAUDE_MAX_BUDGET_USD` must be >= 0
+- `KLAUS_RETRY_BASE_BACKOFF` must be a valid Go duration (e.g. `2s`, `500ms`)

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -87,16 +87,16 @@ All klaus configuration is done via environment variables. Only `ANTHROPIC_API_K
 
 ## Memory augmentation
 
-Requires `KAGENT_MEMORY_ENDPOINT` and `KLAUD_EMBEDDING_MODEL` to be set. When either is absent, memory is silently disabled.
+Requires `KAGENT_MEMORY_ENDPOINT` and `KLAUS_EMBEDDING_MODEL` to be set. When either is absent, memory is silently disabled.
 
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `KAGENT_MEMORY_ENDPOINT` | kagent controller base URL for memory storage/retrieval | -- |
 | `KAGENT_MEMORY_AGENT_NAME` | Agent identifier for memory attribution | `klaus` |
 | `KAGENT_MEMORY_USER_ID` | User identifier for memory attribution | `default` |
-| `KLAUD_EMBEDDING_ENDPOINT` | OpenAI-compatible embedding base URL | `https://api.openai.com/v1` |
-| `KLAUD_EMBEDDING_MODEL` | Embedding model name (e.g. `text-embedding-3-small`); required to enable memory | -- |
-| `KLAUD_EMBEDDING_API_KEY` | API key for the embedding endpoint; omit for unauthenticated endpoints | -- |
+| `KLAUS_EMBEDDING_ENDPOINT` | OpenAI-compatible embedding base URL | `https://api.openai.com/v1` |
+| `KLAUS_EMBEDDING_MODEL` | Embedding model name (e.g. `text-embedding-3-small`); required to enable memory | -- |
+| `KLAUS_EMBEDDING_API_KEY` | API key for the embedding endpoint; omit for unauthenticated endpoints | -- |
 
 ## OTel tracing (server-side)
 

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -74,8 +74,7 @@ All klaus configuration is done via environment variables. Only `ANTHROPIC_API_K
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `KLAUS_RESULT_BACKEND` | Session backend: `local`, `postgres`, or `memory` | `local` |
-| `KLAUS_PG_DSN` | PostgreSQL DSN; required when `KLAUS_RESULT_BACKEND=postgres` | -- |
+| `KLAUS_PGSQL_DSN` | PostgreSQL DSN; when set, Postgres is used as the session backend | -- |
 | `KLAUS_SESSION_DIR` | Override directory for the local backend | -- |
 | `CLAUDE_CONTEXT_ID` | Pre-seed context ID at startup | -- |
 | `CLAUDE_SESSION_ID` | Pre-seed session ID at startup; also passed as `--resume` in chat mode | -- |

--- a/docs/reference/helm-values.md
+++ b/docs/reference/helm-values.md
@@ -79,6 +79,47 @@ claude:
   settingSources: ""          # comma-separated: "user,project,local"
 ```
 
+## Subprocess retry
+
+```yaml
+claude:
+  retryMaxAttempts: 0     # 0 = use default (3)
+  retryBaseBackoff: ""    # empty = use default (2s); e.g. "5s"
+```
+
+## Session store
+
+```yaml
+session:
+  backend: "local"          # local, postgres, or memory
+  postgresSecretName: ""    # Kubernetes Secret with Postgres DSN
+  postgresSecretKey: "dsn"
+  dir: ""                   # override for local backend
+  contextID: ""             # pre-seed context ID at startup
+  sessionID: ""             # pre-seed session ID; --resume in chat mode
+```
+
+## kagent
+
+```yaml
+kagent:
+  endpoint: ""              # kagent controller URL; enables turn push to kagent UI
+```
+
+## Memory augmentation
+
+```yaml
+memory:
+  kagentEndpoint: ""        # kagent controller URL for memory storage/retrieval
+  agentName: "klaus"
+  userID: "default"
+  embedding:
+    endpoint: ""            # OpenAI-compatible base URL (default: api.openai.com/v1)
+    model: ""               # required to enable memory (e.g. text-embedding-3-small)
+    secretName: ""          # Kubernetes Secret with embedding API key
+    secretKey: "api-key"
+```
+
 ## Workspace
 
 ```yaml

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/creativeprojects/go-selfupdate v1.5.2
 	github.com/giantswarm/mcp-oauth v0.2.194
 	github.com/giantswarm/mcp-toolkit v0.2.7
+	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/mark3labs/mcp-go v0.54.1
 	github.com/prometheus/client_golang v1.23.2
@@ -35,7 +36,6 @@ require (
 	github.com/google/go-github/v74 v74.0.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/jsonschema-go v0.4.2 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.8 // indirect

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,8 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel v1.44.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.44.0
+	go.opentelemetry.io/otel/sdk v1.44.0
 	go.opentelemetry.io/otel/trace v1.44.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -65,14 +67,12 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.44.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.44.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.44.0 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.44.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.66.0 // indirect
 	go.opentelemetry.io/otel/exporters/stdout/stdoutlog v0.20.0 // indirect
 	go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.44.0 // indirect
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.44.0 // indirect
 	go.opentelemetry.io/otel/log v0.20.0 // indirect
 	go.opentelemetry.io/otel/metric v1.44.0 // indirect
-	go.opentelemetry.io/otel/sdk v1.44.0 // indirect
 	go.opentelemetry.io/otel/sdk/log v0.20.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.44.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect

--- a/helm/klaus/templates/deployment.yaml
+++ b/helm/klaus/templates/deployment.yaml
@@ -256,6 +256,15 @@ spec:
             # Operating mode
             - name: CLAUDE_MODE
               value: {{ .Values.claude.mode | quote }}
+            # Subprocess watchdog retry
+            {{- if .Values.claude.retryMaxAttempts }}
+            - name: KLAUS_RETRY_MAX_ATTEMPTS
+              value: {{ .Values.claude.retryMaxAttempts | quote }}
+            {{- end }}
+            {{- if .Values.claude.retryBaseBackoff }}
+            - name: KLAUS_RETRY_BASE_BACKOFF
+              value: {{ .Values.claude.retryBaseBackoff | quote }}
+            {{- end }}
             # OpenTelemetry monitoring (Claude Code native telemetry)
             {{- if .Values.telemetry.enabled }}
             - name: CLAUDE_CODE_ENABLE_TELEMETRY
@@ -302,6 +311,63 @@ spec:
             - name: OTEL_RESOURCE_ATTRIBUTES
               value: {{ .Values.telemetry.resourceAttributes | quote }}
             {{- end }}
+            {{- end }}
+            # Session store
+            {{- if .Values.session.backend }}
+            - name: KLAUS_RESULT_BACKEND
+              value: {{ .Values.session.backend | quote }}
+            {{- end }}
+            {{- if .Values.session.postgresSecretName }}
+            - name: KLAUS_PG_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.session.postgresSecretName }}
+                  key: {{ .Values.session.postgresSecretKey }}
+            {{- end }}
+            {{- if .Values.session.dir }}
+            - name: KLAUS_SESSION_DIR
+              value: {{ .Values.session.dir | quote }}
+            {{- end }}
+            {{- if .Values.session.contextID }}
+            - name: CLAUDE_CONTEXT_ID
+              value: {{ .Values.session.contextID | quote }}
+            {{- end }}
+            {{- if .Values.session.sessionID }}
+            - name: CLAUDE_SESSION_ID
+              value: {{ .Values.session.sessionID | quote }}
+            {{- end }}
+            # kagent integration
+            {{- if .Values.kagent.endpoint }}
+            - name: KAGENT_API_ENDPOINT
+              value: {{ .Values.kagent.endpoint | quote }}
+            {{- end }}
+            # Memory augmentation
+            {{- if .Values.memory.kagentEndpoint }}
+            - name: KAGENT_MEMORY_ENDPOINT
+              value: {{ .Values.memory.kagentEndpoint | quote }}
+            {{- end }}
+            {{- if .Values.memory.agentName }}
+            - name: KAGENT_MEMORY_AGENT_NAME
+              value: {{ .Values.memory.agentName | quote }}
+            {{- end }}
+            {{- if .Values.memory.userID }}
+            - name: KAGENT_MEMORY_USER_ID
+              value: {{ .Values.memory.userID | quote }}
+            {{- end }}
+            {{- if .Values.memory.embedding.endpoint }}
+            - name: KLAUD_EMBEDDING_ENDPOINT
+              value: {{ .Values.memory.embedding.endpoint | quote }}
+            {{- end }}
+            {{- if .Values.memory.embedding.model }}
+            - name: KLAUD_EMBEDDING_MODEL
+              value: {{ .Values.memory.embedding.model | quote }}
+            {{- end }}
+            {{- if .Values.memory.embedding.secretName }}
+            - name: KLAUD_EMBEDDING_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.memory.embedding.secretName }}
+                  key: {{ .Values.memory.embedding.secretKey }}
             {{- end }}
           volumeMounts:
             {{- if or .Values.claude.mcpConfig (include "klaus.hasMcpServers" .) }}

--- a/helm/klaus/templates/deployment.yaml
+++ b/helm/klaus/templates/deployment.yaml
@@ -313,12 +313,8 @@ spec:
             {{- end }}
             {{- end }}
             # Session store
-            {{- if .Values.session.backend }}
-            - name: KLAUS_RESULT_BACKEND
-              value: {{ .Values.session.backend | quote }}
-            {{- end }}
             {{- if .Values.session.postgresSecretName }}
-            - name: KLAUS_PG_DSN
+            - name: KLAUS_PGSQL_DSN
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.session.postgresSecretName }}

--- a/helm/klaus/templates/deployment.yaml
+++ b/helm/klaus/templates/deployment.yaml
@@ -351,15 +351,15 @@ spec:
               value: {{ .Values.memory.userID | quote }}
             {{- end }}
             {{- if .Values.memory.embedding.endpoint }}
-            - name: KLAUD_EMBEDDING_ENDPOINT
+            - name: KLAUS_EMBEDDING_ENDPOINT
               value: {{ .Values.memory.embedding.endpoint | quote }}
             {{- end }}
             {{- if .Values.memory.embedding.model }}
-            - name: KLAUD_EMBEDDING_MODEL
+            - name: KLAUS_EMBEDDING_MODEL
               value: {{ .Values.memory.embedding.model | quote }}
             {{- end }}
             {{- if .Values.memory.embedding.secretName }}
-            - name: KLAUD_EMBEDDING_API_KEY
+            - name: KLAUS_EMBEDDING_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.memory.embedding.secretName }}

--- a/helm/klaus/values.yaml
+++ b/helm/klaus/values.yaml
@@ -221,6 +221,14 @@ claude:
   #       sessions saved to disk (interactive multi-turn chat).
   mode: agent
 
+  # -- Subprocess watchdog retry --
+  # retryMaxAttempts is the maximum number of subprocess restarts by the watchdog.
+  # 0 means use the default (3).
+  retryMaxAttempts: 0
+  # retryBaseBackoff is the initial backoff before the first restart (e.g. "2s").
+  # Each subsequent attempt doubles the duration. Empty means use the default (2s).
+  retryBaseBackoff: ""
+
 # Owner-based access control.
 # When set, only the user whose JWT sub or email claim matches this value
 # can access the /mcp endpoint. Other authenticated users receive HTTP 403.
@@ -275,6 +283,61 @@ workspace:
   #       cpu: 500m
   #       memory: 512Mi
   gitResources: {}
+
+# Session store configuration.
+# Maps A2A context IDs to Claude session IDs and stores conversation turn history.
+session:
+  # backend selects the session store: "local" (filesystem), "postgres", or "memory".
+  # "memory" is for testing only — all state is lost on pod restart.
+  backend: "local"
+  # postgresSecretName references a Kubernetes Secret containing the Postgres DSN
+  # (key specified by postgresSecretKey). Required when backend=postgres.
+  postgresSecretName: ""
+  postgresSecretKey: "dsn"
+  # dir overrides the directory used by the local backend.
+  # Defaults to $HOME/.claude/projects when empty.
+  dir: ""
+  # contextID and sessionID pre-seed the session store at startup.
+  # Set these when the pod should resume a specific conversation without
+  # requiring a first-turn round-trip. In chat mode, sessionID is also passed
+  # as --resume to the Claude subprocess.
+  contextID: ""
+  sessionID: ""
+
+# kagent integration.
+# When endpoint is set, completed A2A turns are pushed to the kagent
+# session-events API so that conversations appear in the kagent UI.
+kagent:
+  # endpoint is the kagent controller base URL (e.g. http://kagent.kagent.svc).
+  endpoint: ""
+
+# Memory augmentation.
+# Before each A2A turn, relevant chunks from previous sessions are retrieved
+# and prepended to the user prompt. Turns are stored after each round.
+# Requires both kagentEndpoint and embedding.model to be set.
+memory:
+  # kagentEndpoint is the kagent controller base URL for memory storage/retrieval.
+  # Uses the pgvector-backed memory API. Leave empty to disable memory augmentation.
+  kagentEndpoint: ""
+  # agentName is the agent identifier used when storing memory entries.
+  agentName: "klaus"
+  # userID is the user identifier for memory attribution.
+  userID: "default"
+  # embedding configures the OpenAI-compatible embedding endpoint used to generate
+  # 768-dim vectors for similarity search. model is required; endpoint defaults
+  # to the OpenAI API.
+  embedding:
+    # endpoint is the OpenAI-compatible base URL.
+    # Defaults to https://api.openai.com/v1 when empty.
+    endpoint: ""
+    # model is the embedding model name (e.g. "text-embedding-3-small").
+    # Required to enable memory augmentation; leaving this empty disables memory
+    # even when kagentEndpoint is set.
+    model: ""
+    # secretName references a Kubernetes Secret containing the embedding API key.
+    # Leave empty for unauthenticated endpoints (e.g. a local vLLM instance).
+    secretName: ""
+    secretKey: "api-key"
 
 # OpenTelemetry monitoring configuration.
 # These env vars are inherited by the Claude Code subprocess, enabling its

--- a/helm/klaus/values.yaml
+++ b/helm/klaus/values.yaml
@@ -287,13 +287,11 @@ workspace:
 # Session store configuration.
 # Maps A2A context IDs to Claude session IDs and stores conversation turn history.
 session:
-  # backend selects the session store: "local" (filesystem), "postgres", or "memory".
-  # "memory" is for testing only — all state is lost on pod restart.
-  backend: "local"
   # postgresSecretName references a Kubernetes Secret containing the Postgres DSN
-  # (key specified by postgresSecretKey). Required when backend=postgres.
+  # under postgresSecretKey. When set, Postgres is used; otherwise the local
+  # file store under KLAUS_SESSION_DIR (or ~/.klaus/sessions) is used.
   postgresSecretName: ""
-  postgresSecretKey: "dsn"
+  postgresSecretKey: "uri"
   # dir overrides the directory used by the local backend.
   # Defaults to $HOME/.claude/projects when empty.
   dir: ""

--- a/pkg/a2a/card.go
+++ b/pkg/a2a/card.go
@@ -32,13 +32,24 @@ func AgentCard() *a2a.AgentCard {
 	url := envOrDefault(envAgentURL, "http://localhost:8080/a2a")
 
 	return &a2a.AgentCard{
-		Name:        name,
-		Description: description,
-		Version:     version,
-		URL:         url,
+		Name:               name,
+		Description:        description,
+		Version:            version,
+		URL:                url,
+		ProtocolVersion:    string(a2a.Version),
+		DefaultInputModes:  []string{"text/plain"},
+		DefaultOutputModes: []string{"text/plain"},
 		Capabilities: a2a.AgentCapabilities{
 			Streaming:         true,
 			PushNotifications: false,
+		},
+		Skills: []a2a.AgentSkill{
+			{
+				ID:          "claude-code",
+				Name:        name,
+				Description: description,
+				Tags:        []string{"coding", "ai", "claude"},
+			},
 		},
 	}
 }

--- a/pkg/a2a/events.go
+++ b/pkg/a2a/events.go
@@ -8,6 +8,8 @@
 package a2a
 
 import (
+	"strings"
+
 	"github.com/a2aproject/a2a-go/a2a"
 	"github.com/a2aproject/a2a-go/a2asrv"
 )
@@ -69,15 +71,16 @@ func canceledEvent(reqCtx *a2asrv.RequestContext) *a2a.TaskStatusUpdateEvent {
 	return ev
 }
 
-// extractText pulls the first non-empty text part from an A2A message.
+// extractText concatenates all text parts from an A2A message.
 func extractText(msg *a2a.Message) string {
 	if msg == nil {
 		return ""
 	}
+	var sb strings.Builder
 	for _, part := range msg.Parts {
-		if tp, ok := part.(a2a.TextPart); ok && tp.Text != "" {
-			return tp.Text
+		if tp, ok := part.(a2a.TextPart); ok {
+			sb.WriteString(tp.Text)
 		}
 	}
-	return ""
+	return sb.String()
 }

--- a/pkg/a2a/executor.go
+++ b/pkg/a2a/executor.go
@@ -373,6 +373,14 @@ func (e *Executor) recordTurns(parentCtx context.Context, contextID, sessionID, 
 				log.Printf("[a2a] memory store assistant failed contextID=%q: %v", contextID, err)
 			}
 		}
+
+		// Store the turn as a completed A2A task so the kagent UI can render
+		// conversation history on reload. kagent's BYO passthrough proxy does
+		// not persist tasks itself; GET /api/sessions/{id}/tasks would return
+		// empty without this call.
+		if e.kagent != nil && userText != "" && assistantText != "" {
+			e.kagent.StoreTask(ctx, newEventID(), contextID, userText, assistantText)
+		}
 	}()
 }
 

--- a/pkg/a2a/executor.go
+++ b/pkg/a2a/executor.go
@@ -46,12 +46,13 @@ type Executor struct {
 	mem      memory.Client
 	mode     Mode
 
-	// mu protects contextMu.
+	// mu protects inFlight.
 	mu sync.Mutex
-	// contextMu maps contextID to its per-context lock, preventing concurrent
-	// executions within the same conversation. A second request while one is
-	// in flight receives a rejected event.
-	contextMu map[string]*sync.Mutex
+	// inFlight tracks contextIDs that currently have an Execute in progress.
+	// A second request for the same contextID while one is in flight receives
+	// a rejected event. Using a presence-set avoids the unlock-then-delete
+	// race that a per-context mutex map would have.
+	inFlight map[string]struct{}
 }
 
 var _ a2asrv.AgentExecutor = (*Executor)(nil)
@@ -67,12 +68,12 @@ func New(prompter claude.Prompter, store session.Store, mode Mode, kagentClient 
 		memClient = memory.NoOp{}
 	}
 	return &Executor{
-		prompter:  prompter,
-		store:     store,
-		kagent:    kagentClient,
-		mem:       memClient,
-		mode:      mode,
-		contextMu: make(map[string]*sync.Mutex),
+		prompter: prompter,
+		store:    store,
+		kagent:   kagentClient,
+		mem:      memClient,
+		mode:     mode,
+		inFlight: make(map[string]struct{}),
 	}
 }
 
@@ -95,22 +96,20 @@ func (e *Executor) Execute(ctx context.Context, reqCtx *a2asrv.RequestContext, q
 		))
 	span.End()
 
-	// Acquire the per-context lock; reject if already in-flight.
-	mu := e.lockForContext(contextID)
-	if !mu.TryLock() {
+	// Acquire the per-context in-flight slot; reject if already running.
+	if !e.lockForContext(contextID) {
 		log.Printf("[a2a] contextID %q already in-flight, rejecting", contextID)
 		return queue.Write(ctx, rejectedEvent(reqCtx, "another request for this context is already in-flight"))
 	}
-	defer func() {
-		mu.Unlock()
-		e.releaseContext(contextID)
-	}()
+	defer e.releaseContext(contextID)
 
 	// Extract prompt text.
 	text := extractText(reqCtx.Message)
 	if text == "" {
 		return queue.Write(ctx, failedEvent(reqCtx, "message contains no text content"))
 	}
+
+	log.Printf("[a2a] turn start contextID=%q prompt=%q", contextID, claude.Truncate(text, 120))
 
 	// Intercept TUI-only slash commands.
 	if cmd, ok := interceptSlashCommand(text); ok {
@@ -149,43 +148,58 @@ func (e *Executor) Execute(ctx context.Context, reqCtx *a2asrv.RequestContext, q
 	}
 
 	// Drain the stream, emit working events for text chunks, and collect all
-	// messages so we can extract the result from the MessageTypeResult message.
-	// Status().Result is only populated after Submit(); RunWithOptions leaves
-	// status as Idle, so we must derive the result from the stream itself.
+	// messages for result extraction and session ID discovery.
 	var lastText string
 	var messages []claude.StreamMessage
-	for msg := range ch {
+	var streamSessionID string
+drainLoop:
+	for {
 		select {
 		case <-ctx.Done():
+			// Stop the subprocess so it doesn't block indefinitely after the
+			// caller cancels; without this the stdout goroutine fills the 100-
+			// message buffer and cmd.Wait never returns, leaving status Busy.
+			_ = e.prompter.Stop()
 			return ctx.Err()
-		default:
-		}
-
-		messages = append(messages, msg)
-		if msg.Type == claude.MessageTypeStreamEvent || msg.Type == claude.MessageTypeAssistant {
-			if msg.Text != "" && msg.Text != lastText {
-				lastText = msg.Text
-				if writeErr := queue.Write(ctx, workingEvent(reqCtx, claude.Truncate(msg.Text, 200))); writeErr != nil {
-					log.Printf("[a2a] write working chunk: %v", writeErr)
+		case msg, ok := <-ch:
+			if !ok {
+				break drainLoop
+			}
+			messages = append(messages, msg)
+			if msg.Type == claude.MessageTypeSystem && msg.SessionID != "" {
+				streamSessionID = msg.SessionID
+				log.Printf("[a2a] session contextID=%q sessionID=%q", contextID, msg.SessionID)
+			}
+			if msg.Type == claude.MessageTypeAssistant && msg.Subtype == claude.SubtypeToolUse {
+				log.Printf("[a2a] tool_use contextID=%q tool=%q", contextID, msg.ToolName)
+			}
+			if msg.Type == claude.MessageTypeStreamEvent || msg.Type == claude.MessageTypeAssistant {
+				if msg.Text != "" && msg.Text != lastText {
+					lastText = msg.Text
+					if writeErr := queue.Write(ctx, workingEvent(reqCtx, claude.Truncate(msg.Text, 200))); writeErr != nil {
+						log.Printf("[a2a] write working chunk: %v", writeErr)
+					}
 				}
 			}
 		}
 	}
 
-	// Collect result and bind session.
-	status := e.prompter.Status()
-	sessionID := status.SessionID
-	result := status.Result
-	if result == "" {
-		detail := e.prompter.ResultDetail()
-		result = detail.ResultText
+	// Log the raw result for console visibility (kubectl logs).
+	log.Printf("[a2a] turn done contextID=%q messages=%d", contextID, len(messages))
+
+	// Derive the result from the stream only. Status().Result is NOT consulted
+	// because RunWithOptions leaves the process Idle; the disk fallback in
+	// Status() would serve a stale result from a previous MCP Submit.
+	result := claude.CollectResultText(messages)
+
+	if result != "" {
+		log.Printf("[a2a] result contextID=%q result=%q", contextID, claude.Truncate(result, 500))
 	}
-	// Fallback: extract result from the stream messages directly. This covers
-	// the RunWithOptions path where status remains Idle (not Completed) and
-	// p.result is never written.
-	if result == "" {
-		result = claude.CollectResultText(messages)
-	}
+
+	// Use the sessionID observed in this run's stream. Status().SessionID is
+	// NOT consulted because p.sessionID is reset at run start but may still
+	// carry a prior value if no system message arrives (e.g. early crash).
+	sessionID := streamSessionID
 
 	if sessionID != "" {
 		if bindErr := e.store.BindSession(ctx, contextID, sessionID); bindErr != nil {
@@ -197,6 +211,10 @@ func (e *Executor) Execute(ctx context.Context, reqCtx *a2asrv.RequestContext, q
 	// writes are async and best-effort so they never block the response path.
 	e.recordTurns(contextID, sessionID, text, result)
 
+	// Query status only for error / retry-state detection; Result and SessionID
+	// fields are intentionally not used (see result/sessionID derivation above).
+	status := e.prompter.Status()
+
 	if status.Status == claude.ProcessStatusError {
 		errMsg := status.ErrorMessage
 		if errMsg == "" {
@@ -205,13 +223,12 @@ func (e *Executor) Execute(ctx context.Context, reqCtx *a2asrv.RequestContext, q
 		return queue.Write(ctx, failedEvent(reqCtx, errMsg))
 	}
 
-	// Write the full result as a final artifact.
+	// If the subprocess is still Busy after the stream closed and we have no
+	// result, it is mid-retry (PersistentProcess recovering from a crash).
+	// Fail the turn rather than emitting a terminal completed with no artifact.
 	if result == "" && status.Status == claude.ProcessStatusBusy {
-		// Mid-retry: the subprocess is recovering. Emit a status hint.
-		retryMsg := fmt.Sprintf("reconnecting, attempt %d", status.RetryCount)
-		if writeErr := queue.Write(ctx, workingEvent(reqCtx, retryMsg)); writeErr != nil {
-			return fmt.Errorf("write retry working: %w", writeErr)
-		}
+		retryMsg := fmt.Sprintf("subprocess is recovering (attempt %d); no result produced", status.RetryCount)
+		return queue.Write(ctx, failedEvent(reqCtx, retryMsg))
 	}
 
 	if result != "" {
@@ -332,23 +349,24 @@ func (e *Executor) recordTurns(contextID, sessionID, userText, assistantText str
 	}()
 }
 
-// lockForContext returns (and lazily creates) the per-contextID mutex. The
-// returned mutex is not held; callers must call TryLock/Lock themselves.
-func (e *Executor) lockForContext(contextID string) *sync.Mutex {
+// lockForContext marks contextID as in-flight. Returns true if the slot was
+// acquired (caller may proceed), false if contextID was already in-flight
+// (caller should reject). The in-flight flag is set atomically under e.mu,
+// eliminating the unlock-then-delete race that a per-context mutex map has.
+func (e *Executor) lockForContext(contextID string) bool {
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	mu, ok := e.contextMu[contextID]
-	if !ok {
-		mu = &sync.Mutex{}
-		e.contextMu[contextID] = mu
+	if _, ok := e.inFlight[contextID]; ok {
+		return false
 	}
-	return mu
+	e.inFlight[contextID] = struct{}{}
+	return true
 }
 
-// releaseContext removes the per-context mutex once a context is no longer
-// in-flight. This prevents the map from growing unboundedly.
+// releaseContext clears the in-flight marker for contextID. This prevents
+// the map from growing unboundedly and unblocks the next request.
 func (e *Executor) releaseContext(contextID string) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	delete(e.contextMu, contextID)
+	delete(e.inFlight, contextID)
 }

--- a/pkg/a2a/executor.go
+++ b/pkg/a2a/executor.go
@@ -185,6 +185,53 @@ drainLoop:
 		}
 	}
 
+	// Stale resume: subprocess exited with no session ID — the session file was
+	// lost (e.g. pod restart with emptyDir workspace). Retry once with a fresh
+	// session using the deterministic context-derived ID so the turn succeeds.
+	// The stale Postgres binding is overwritten by BindSession after the retry.
+	if runOpts != nil && runOpts.Resume != "" && streamSessionID == "" &&
+		e.prompter.Status().Status == claude.ProcessStatusError {
+		log.Printf("[a2a] stale session resume contextID=%q, retrying fresh", contextID)
+		retryOpts := &claude.RunOptions{
+			SaveSession: true,
+			SessionID:   sessionIDFromContext(contextID),
+		}
+		if retryCh, retryErr := e.prompter.RunWithOptions(ctx, augmented, retryOpts); retryErr == nil {
+			messages = messages[:0]
+			lastText = ""
+		retryDrainLoop:
+			for {
+				select {
+				case <-ctx.Done():
+					_ = e.prompter.Stop()
+					return ctx.Err()
+				case msg, ok := <-retryCh:
+					if !ok {
+						break retryDrainLoop
+					}
+					messages = append(messages, msg)
+					if msg.Type == claude.MessageTypeSystem && msg.SessionID != "" {
+						streamSessionID = msg.SessionID
+						log.Printf("[a2a] retry session contextID=%q sessionID=%q", contextID, msg.SessionID)
+					}
+					if msg.Type == claude.MessageTypeAssistant && msg.Subtype == claude.SubtypeToolUse {
+						log.Printf("[a2a] tool_use (retry) contextID=%q tool=%q", contextID, msg.ToolName)
+					}
+					if msg.Type == claude.MessageTypeStreamEvent || msg.Type == claude.MessageTypeAssistant {
+						if msg.Text != "" && msg.Text != lastText {
+							lastText = msg.Text
+							if writeErr := queue.Write(ctx, workingEvent(reqCtx, claude.Truncate(msg.Text, 200))); writeErr != nil {
+								log.Printf("[a2a] write working chunk (retry): %v", writeErr)
+							}
+						}
+					}
+				}
+			}
+		} else {
+			log.Printf("[a2a] retry RunWithOptions failed contextID=%q: %v", contextID, retryErr)
+		}
+	}
+
 	// Log the raw result for console visibility (kubectl logs).
 	log.Printf("[a2a] turn done contextID=%q messages=%d", contextID, len(messages))
 

--- a/pkg/a2a/executor.go
+++ b/pkg/a2a/executor.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/a2aproject/a2a-go/a2asrv"
 	"github.com/a2aproject/a2a-go/a2asrv/eventqueue"
+	"github.com/google/uuid"
 
 	"github.com/giantswarm/klaus/pkg/claude"
 	"github.com/giantswarm/klaus/pkg/kagentapi"
@@ -209,7 +210,7 @@ drainLoop:
 
 	// Record user prompt and assistant reply as conversation turns. Both
 	// writes are async and best-effort so they never block the response path.
-	e.recordTurns(contextID, sessionID, text, result)
+	e.recordTurns(ctx, contextID, sessionID, text, result)
 
 	// Query status only for error / retry-state detection; Result and SessionID
 	// fields are intentionally not used (see result/sessionID derivation above).
@@ -322,10 +323,18 @@ func (e *Executor) augmentWithMemory(ctx context.Context, contextID, text string
 // recordTurns persists the user prompt and assistant reply as conversation
 // turns in the store, then pushes them to the kagent UI. Both operations are
 // async and best-effort: failures are logged only, never returned.
-func (e *Executor) recordTurns(contextID, sessionID, userText, assistantText string) {
+//
+// parentCtx carries the caller's OIDC AuthInfo (set by extractCallerAuth
+// middleware). It is captured before the goroutine so the goroutine can
+// re-inject it into the detached timeout context for kagent auth.
+func (e *Executor) recordTurns(parentCtx context.Context, contextID, sessionID, userText, assistantText string) {
+	authInfo := kagentapi.AuthInfoFromContext(parentCtx)
 	go func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
+		if authInfo.BearerToken != "" {
+			ctx = kagentapi.WithAuthInfo(ctx, authInfo)
+		}
 
 		if userText != "" {
 			userContent, _ := json.Marshal(userText)
@@ -339,7 +348,7 @@ func (e *Executor) recordTurns(contextID, sessionID, userText, assistantText str
 				log.Printf("[a2a] AppendTurn user failed contextID=%q: %v", contextID, err)
 			}
 			if e.kagent != nil {
-				e.kagent.PushEvent(ctx, contextID, kagentapi.SessionEvent{Role: "user", Content: userText})
+				e.kagent.PushEvent(ctx, contextID, kagentapi.NewSessionEvent(newEventID(), "user", userText))
 			}
 			if err := e.mem.Store(ctx, contextID, "user", userText); err != nil {
 				log.Printf("[a2a] memory store user failed contextID=%q: %v", contextID, err)
@@ -358,7 +367,7 @@ func (e *Executor) recordTurns(contextID, sessionID, userText, assistantText str
 				log.Printf("[a2a] AppendTurn assistant failed contextID=%q: %v", contextID, err)
 			}
 			if e.kagent != nil {
-				e.kagent.PushEvent(ctx, contextID, kagentapi.SessionEvent{Role: "assistant", Content: assistantText})
+				e.kagent.PushEvent(ctx, contextID, kagentapi.NewSessionEvent(newEventID(), "agent", assistantText))
 			}
 			if err := e.mem.Store(ctx, contextID, "assistant", assistantText); err != nil {
 				log.Printf("[a2a] memory store assistant failed contextID=%q: %v", contextID, err)
@@ -388,3 +397,5 @@ func (e *Executor) releaseContext(contextID string) {
 	defer e.mu.Unlock()
 	delete(e.inFlight, contextID)
 }
+
+func newEventID() string { return uuid.New().String() }

--- a/pkg/a2a/executor.go
+++ b/pkg/a2a/executor.go
@@ -148,8 +148,12 @@ func (e *Executor) Execute(ctx context.Context, reqCtx *a2asrv.RequestContext, q
 		return queue.Write(ctx, failedEvent(reqCtx, "agent error: "+err.Error()))
 	}
 
-	// Drain the stream and emit working events for text chunks.
+	// Drain the stream, emit working events for text chunks, and collect all
+	// messages so we can extract the result from the MessageTypeResult message.
+	// Status().Result is only populated after Submit(); RunWithOptions leaves
+	// status as Idle, so we must derive the result from the stream itself.
 	var lastText string
+	var messages []claude.StreamMessage
 	for msg := range ch {
 		select {
 		case <-ctx.Done():
@@ -157,6 +161,7 @@ func (e *Executor) Execute(ctx context.Context, reqCtx *a2asrv.RequestContext, q
 		default:
 		}
 
+		messages = append(messages, msg)
 		if msg.Type == claude.MessageTypeStreamEvent || msg.Type == claude.MessageTypeAssistant {
 			if msg.Text != "" && msg.Text != lastText {
 				lastText = msg.Text
@@ -174,6 +179,12 @@ func (e *Executor) Execute(ctx context.Context, reqCtx *a2asrv.RequestContext, q
 	if result == "" {
 		detail := e.prompter.ResultDetail()
 		result = detail.ResultText
+	}
+	// Fallback: extract result from the stream messages directly. This covers
+	// the RunWithOptions path where status remains Idle (not Completed) and
+	// p.result is never written.
+	if result == "" {
+		result = claude.CollectResultText(messages)
 	}
 
 	if sessionID != "" {

--- a/pkg/a2a/executor.go
+++ b/pkg/a2a/executor.go
@@ -272,10 +272,28 @@ func (e *Executor) runOptions(ctx context.Context, contextID string) (*claude.Ru
 		return nil, err
 	}
 
-	return &claude.RunOptions{
-		Resume:      sessionID,
-		SaveSession: true,
-	}, nil
+	opts := &claude.RunOptions{SaveSession: true}
+	if sessionID != "" {
+		// Resume the session from the prior turn.
+		opts.Resume = sessionID
+	} else {
+		// First turn: seed the Claude session with a deterministic ID derived
+		// from the A2A contextID so the Claude session file is traceable to the
+		// same UUID that the kagent UI displays.
+		opts.SessionID = sessionIDFromContext(contextID)
+	}
+	return opts, nil
+}
+
+// sessionIDFromContext derives a Claude session ID from an A2A contextID.
+// A2A context IDs are typically "ctx-<uuid>"; the UUID part is extracted so
+// the Claude session file is named by the same UUID the kagent UI displays.
+// If contextID is already a plain UUID (no prefix), it is returned as-is.
+func sessionIDFromContext(contextID string) string {
+	if after, ok := strings.CutPrefix(contextID, "ctx-"); ok {
+		return after
+	}
+	return contextID
 }
 
 // augmentWithMemory retrieves relevant memory chunks and prepends them to
@@ -320,8 +338,8 @@ func (e *Executor) recordTurns(contextID, sessionID, userText, assistantText str
 			}); err != nil {
 				log.Printf("[a2a] AppendTurn user failed contextID=%q: %v", contextID, err)
 			}
-			if e.kagent != nil && sessionID != "" {
-				e.kagent.PushEvent(ctx, sessionID, kagentapi.SessionEvent{Role: "user", Content: userText})
+			if e.kagent != nil {
+				e.kagent.PushEvent(ctx, contextID, kagentapi.SessionEvent{Role: "user", Content: userText})
 			}
 			if err := e.mem.Store(ctx, contextID, "user", userText); err != nil {
 				log.Printf("[a2a] memory store user failed contextID=%q: %v", contextID, err)
@@ -339,8 +357,8 @@ func (e *Executor) recordTurns(contextID, sessionID, userText, assistantText str
 			}); err != nil {
 				log.Printf("[a2a] AppendTurn assistant failed contextID=%q: %v", contextID, err)
 			}
-			if e.kagent != nil && sessionID != "" {
-				e.kagent.PushEvent(ctx, sessionID, kagentapi.SessionEvent{Role: "assistant", Content: assistantText})
+			if e.kagent != nil {
+				e.kagent.PushEvent(ctx, contextID, kagentapi.SessionEvent{Role: "assistant", Content: assistantText})
 			}
 			if err := e.mem.Store(ctx, contextID, "assistant", assistantText); err != nil {
 				log.Printf("[a2a] memory store assistant failed contextID=%q: %v", contextID, err)

--- a/pkg/a2a/executor.go
+++ b/pkg/a2a/executor.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"strings"
 	"sync"
 	"time"
 
@@ -17,6 +18,7 @@ import (
 
 	"github.com/giantswarm/klaus/pkg/claude"
 	"github.com/giantswarm/klaus/pkg/kagentapi"
+	"github.com/giantswarm/klaus/pkg/memory"
 	"github.com/giantswarm/klaus/pkg/session"
 	"github.com/giantswarm/klaus/pkg/telemetry"
 )
@@ -41,6 +43,7 @@ type Executor struct {
 	prompter claude.Prompter
 	store    session.Store
 	kagent   *kagentapi.Client
+	mem      memory.Client
 	mode     Mode
 
 	// mu protects contextMu.
@@ -57,11 +60,17 @@ var _ a2asrv.AgentExecutor = (*Executor)(nil)
 // mode) or a *claude.PersistentProcess (chat mode). store persists
 // contextID→sessionID bindings across turns. kagentClient may be nil; when
 // non-nil and enabled, completed turns are pushed to the kagent UI.
-func New(prompter claude.Prompter, store session.Store, mode Mode, kagentClient *kagentapi.Client) *Executor {
+// memClient handles semantic memory retrieval and storage; pass memory.NoOp{}
+// to disable memory augmentation.
+func New(prompter claude.Prompter, store session.Store, mode Mode, kagentClient *kagentapi.Client, memClient memory.Client) *Executor {
+	if memClient == nil {
+		memClient = memory.NoOp{}
+	}
 	return &Executor{
 		prompter:  prompter,
 		store:     store,
 		kagent:    kagentClient,
+		mem:       memClient,
 		mode:      mode,
 		contextMu: make(map[string]*sync.Mutex),
 	}
@@ -126,8 +135,11 @@ func (e *Executor) Execute(ctx context.Context, reqCtx *a2asrv.RequestContext, q
 		// Non-fatal: proceed without resume.
 	}
 
+	// Retrieve semantic memory and prepend relevant past context to the prompt.
+	augmented := e.augmentWithMemory(ctx, contextID, text)
+
 	// Run the prompt.
-	ch, err := e.prompter.RunWithOptions(ctx, text, runOpts)
+	ch, err := e.prompter.RunWithOptions(ctx, augmented, runOpts)
 	if err != nil {
 		if errors.Is(err, claude.ErrBusy) {
 			return queue.Write(ctx, rejectedEvent(reqCtx, "agent subprocess is busy"))
@@ -238,6 +250,29 @@ func (e *Executor) runOptions(ctx context.Context, contextID string) (*claude.Ru
 	}, nil
 }
 
+// augmentWithMemory retrieves relevant memory chunks and prepends them to
+// the prompt text. Returns text unchanged when memory is unavailable or empty.
+func (e *Executor) augmentWithMemory(ctx context.Context, contextID, text string) string {
+	chunks, err := e.mem.Retrieve(ctx, contextID, text, 5)
+	if err != nil {
+		log.Printf("[a2a] memory retrieve failed contextID=%q: %v", contextID, err)
+		return text
+	}
+	if len(chunks) == 0 {
+		return text
+	}
+	var sb strings.Builder
+	sb.WriteString("[Relevant memory from previous sessions]\n")
+	for _, c := range chunks {
+		sb.WriteString("- ")
+		sb.WriteString(c.Content)
+		sb.WriteByte('\n')
+	}
+	sb.WriteString("\n")
+	sb.WriteString(text)
+	return sb.String()
+}
+
 // recordTurns persists the user prompt and assistant reply as conversation
 // turns in the store, then pushes them to the kagent UI. Both operations are
 // async and best-effort: failures are logged only, never returned.
@@ -260,6 +295,9 @@ func (e *Executor) recordTurns(contextID, sessionID, userText, assistantText str
 			if e.kagent != nil && sessionID != "" {
 				e.kagent.PushEvent(ctx, sessionID, kagentapi.SessionEvent{Role: "user", Content: userText})
 			}
+			if err := e.mem.Store(ctx, contextID, "user", userText); err != nil {
+				log.Printf("[a2a] memory store user failed contextID=%q: %v", contextID, err)
+			}
 		}
 
 		if assistantText != "" {
@@ -275,6 +313,9 @@ func (e *Executor) recordTurns(contextID, sessionID, userText, assistantText str
 			}
 			if e.kagent != nil && sessionID != "" {
 				e.kagent.PushEvent(ctx, sessionID, kagentapi.SessionEvent{Role: "assistant", Content: assistantText})
+			}
+			if err := e.mem.Store(ctx, contextID, "assistant", assistantText); err != nil {
+				log.Printf("[a2a] memory store assistant failed contextID=%q: %v", contextID, err)
 			}
 		}
 	}()

--- a/pkg/a2a/executor_test.go
+++ b/pkg/a2a/executor_test.go
@@ -307,6 +307,95 @@ func (b *blockingPrompter) RunWithOptions(ctx context.Context, prompt string, op
 	return ch, nil
 }
 
+func TestExecutor_SubprocessError(t *testing.T) {
+	prompter := &fakePrompter{
+		statusVal: claude.StatusInfo{
+			Status:       claude.ProcessStatusError,
+			ErrorMessage: "subprocess exited with code 1",
+		},
+	}
+	store := session.NewMemoryStore()
+	exec := a2a.New(prompter, store, a2a.ModeChat, nil, memory.NoOp{})
+
+	queue := &captureQueue{}
+	err := exec.Execute(t.Context(), makeReqCtx("ctx-err", "hello"), queue)
+	require.NoError(t, err)
+
+	last := queue.events[len(queue.events)-1]
+	statusEv, ok := last.(*a2asdk.TaskStatusUpdateEvent)
+	require.True(t, ok)
+	assert.Equal(t, a2asdk.TaskStateFailed, statusEv.Status.State)
+	assert.True(t, statusEv.Final)
+}
+
+func TestExecutor_CollectResultTextFallback(t *testing.T) {
+	// Status().Result and ResultDetail().ResultText are both empty.
+	// The result must come from the MessageTypeResult message in the stream.
+	resultMsg := claude.StreamMessage{
+		Type:   claude.MessageTypeResult,
+		Result: "full response from stream",
+	}
+	prompter := &fakePrompter{
+		messages:  []claude.StreamMessage{resultMsg},
+		statusVal: claude.StatusInfo{Status: claude.ProcessStatusIdle},
+	}
+	store := session.NewMemoryStore()
+	exec := a2a.New(prompter, store, a2a.ModeChat, nil, memory.NoOp{})
+
+	queue := &captureQueue{}
+	err := exec.Execute(t.Context(), makeReqCtx("ctx-fallback", "hello"), queue)
+	require.NoError(t, err)
+
+	var artifactEv *a2asdk.TaskArtifactUpdateEvent
+	for _, ev := range queue.events {
+		if ae, ok := ev.(*a2asdk.TaskArtifactUpdateEvent); ok {
+			artifactEv = ae
+			break
+		}
+	}
+	require.NotNil(t, artifactEv, "expected artifact-update event from CollectResultText fallback")
+	require.Len(t, artifactEv.Artifact.Parts, 1)
+	tp, ok := artifactEv.Artifact.Parts[0].(a2asdk.TextPart)
+	require.True(t, ok)
+	assert.Equal(t, "full response from stream", tp.Text)
+	assert.True(t, artifactEv.LastChunk)
+}
+
+func TestExecutor_BindSessionSkipsEmpty(t *testing.T) {
+	// When the subprocess returns no sessionID, BindSession must not be called
+	// with "", which would overwrite a prior binding.
+	prompter := &fakePrompter{
+		result: "turn result",
+		statusVal: claude.StatusInfo{
+			Status:    claude.ProcessStatusCompleted,
+			SessionID: "first-session",
+			Result:    "turn result",
+		},
+	}
+	store := session.NewMemoryStore()
+	exec := a2a.New(prompter, store, a2a.ModeAgent, nil, memory.NoOp{})
+
+	// First turn binds the session.
+	q1 := &captureQueue{}
+	err := exec.Execute(t.Context(), makeReqCtx("ctx-bind", "first"), q1)
+	require.NoError(t, err)
+
+	sessID, err := store.SessionID(t.Context(), "ctx-bind")
+	require.NoError(t, err)
+	assert.Equal(t, "first-session", sessID)
+
+	// Second turn: prompter returns empty sessionID (simulates system message not arriving).
+	prompter.statusVal.SessionID = ""
+	q2 := &captureQueue{}
+	err = exec.Execute(t.Context(), makeReqCtx("ctx-bind", "second"), q2)
+	require.NoError(t, err)
+
+	// The binding must still be "first-session", not overwritten with "".
+	sessID, err = store.SessionID(t.Context(), "ctx-bind")
+	require.NoError(t, err)
+	assert.Equal(t, "first-session", sessID)
+}
+
 // TestExecutor_AgentModeResume verifies that the second turn in agent mode
 // passes only --resume (not --session-id), which is what the claude CLI requires.
 func TestExecutor_AgentModeResume(t *testing.T) {

--- a/pkg/a2a/executor_test.go
+++ b/pkg/a2a/executor_test.go
@@ -3,6 +3,7 @@ package a2a_test
 import (
 	"context"
 	"encoding/json"
+	"sync"
 	"testing"
 	"time"
 
@@ -39,8 +40,26 @@ func (f *fakePrompter) RunWithOptions(_ context.Context, _ string, opts *claude.
 	if f.runErr != nil {
 		return nil, f.runErr
 	}
-	ch := make(chan claude.StreamMessage, len(f.messages)+1)
-	for _, m := range f.messages {
+	// Use explicit messages when provided; otherwise synthesise from status
+	// fields so that sessionID and result flow through the stream (as the real
+	// *Process does), not through Status() which the executor no longer reads.
+	msgs := f.messages
+	if len(msgs) == 0 {
+		if f.statusVal.SessionID != "" {
+			msgs = append(msgs, claude.StreamMessage{
+				Type:      claude.MessageTypeSystem,
+				SessionID: f.statusVal.SessionID,
+			})
+		}
+		if f.result != "" {
+			msgs = append(msgs, claude.StreamMessage{
+				Type:   claude.MessageTypeResult,
+				Result: f.result,
+			})
+		}
+	}
+	ch := make(chan claude.StreamMessage, len(msgs)+1)
+	for _, m := range msgs {
 		ch <- m
 	}
 	close(ch)
@@ -79,19 +98,31 @@ func (f *fakePrompter) OpenAIMessages(_ int) claude.OpenAIMessagesInfo {
 }
 func (f *fakePrompter) MarshalStatus() ([]byte, error) { return json.Marshal(f.statusVal) }
 
-// captureQueue collects events written during a test.
+// captureQueue collects events written during a test. It is safe for
+// concurrent use (Execute writes from a goroutine while tests read).
 type captureQueue struct {
+	mu     sync.Mutex
 	events []a2asdk.Event
 }
 
 func (q *captureQueue) Write(_ context.Context, event a2asdk.Event) error {
+	q.mu.Lock()
+	defer q.mu.Unlock()
 	q.events = append(q.events, event)
 	return nil
 }
 
 func (q *captureQueue) WriteVersioned(_ context.Context, event a2asdk.Event, _ a2asdk.TaskVersion) error {
+	q.mu.Lock()
+	defer q.mu.Unlock()
 	q.events = append(q.events, event)
 	return nil
+}
+
+func (q *captureQueue) len() int {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return len(q.events)
 }
 
 func (q *captureQueue) Read(_ context.Context) (a2asdk.Event, a2asdk.TaskVersion, error) {
@@ -135,8 +166,7 @@ func TestExecutor_SlashCommandIntercept(t *testing.T) {
 	assert.True(t, statusEv.Final)
 
 	// The prompter must NOT have been called for intercepted commands.
-	// Since fakePrompter.runErr is nil but we track calls via messages being absent.
-	// No working events should have been emitted before the artifact.
+	require.Empty(t, prompter.capturedOpts, "RunWithOptions must not be called for intercepted slash commands")
 }
 
 func TestExecutor_EmptyText(t *testing.T) {
@@ -247,7 +277,7 @@ func TestExecutor_ConcurrentContextRejected(t *testing.T) {
 	// Give the goroutine time to acquire the lock.
 	// Poll until we see the working event.
 	require.Eventually(t, func() bool {
-		return len(queue1.events) > 0
+		return queue1.len() > 0
 	}, timeout, pollInterval)
 
 	// Second request to the SAME contextID — must be rejected.
@@ -418,12 +448,14 @@ func TestExecutor_AgentModeResume(t *testing.T) {
 	last1 := q1.events[len(q1.events)-1].(*a2asdk.TaskStatusUpdateEvent)
 	assert.Equal(t, a2asdk.TaskStateCompleted, last1.Status.State)
 
-	// First turn RunOptions: Resume should be empty (no prior session); SaveSession must be true.
+	// First turn RunOptions: Resume should be empty (no prior session);
+	// SessionID is seeded from the A2A contextID so the Claude session file
+	// and the kagent UI share the same UUID.
 	require.Len(t, prompter.capturedOpts, 1)
 	opts1 := prompter.capturedOpts[0]
 	require.NotNil(t, opts1)
 	assert.Empty(t, opts1.Resume, "first turn must not pass --resume")
-	assert.Empty(t, opts1.SessionID, "first turn must not pass --session-id")
+	assert.Equal(t, "resume", opts1.SessionID, "first turn must seed --session-id from contextID")
 	assert.True(t, opts1.SaveSession, "first turn must set SaveSession so the conversation is persisted")
 
 	// Second turn — store now has sessionID bound from turn 1.

--- a/pkg/a2a/executor_test.go
+++ b/pkg/a2a/executor_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/giantswarm/klaus/pkg/a2a"
 	"github.com/giantswarm/klaus/pkg/claude"
+	"github.com/giantswarm/klaus/pkg/memory"
 	"github.com/giantswarm/klaus/pkg/session"
 )
 
@@ -115,7 +116,7 @@ func makeReqCtx(contextID string, text string) *a2asrv.RequestContext {
 func TestExecutor_SlashCommandIntercept(t *testing.T) {
 	prompter := &fakePrompter{result: "done"}
 	store := session.NewMemoryStore()
-	exec := a2a.New(prompter, store, a2a.ModeChat, nil)
+	exec := a2a.New(prompter, store, a2a.ModeChat, nil, memory.NoOp{})
 
 	queue := &captureQueue{}
 	reqCtx := makeReqCtx("ctx-1", "/clear please clear the context")
@@ -141,7 +142,7 @@ func TestExecutor_SlashCommandIntercept(t *testing.T) {
 func TestExecutor_EmptyText(t *testing.T) {
 	prompter := &fakePrompter{}
 	store := session.NewMemoryStore()
-	exec := a2a.New(prompter, store, a2a.ModeChat, nil)
+	exec := a2a.New(prompter, store, a2a.ModeChat, nil, memory.NoOp{})
 
 	queue := &captureQueue{}
 	reqCtx := makeReqCtx("ctx-2", "")
@@ -159,7 +160,7 @@ func TestExecutor_EmptyText(t *testing.T) {
 func TestExecutor_BusyReturnsRejected(t *testing.T) {
 	prompter := &fakePrompter{runErr: claude.ErrBusy}
 	store := session.NewMemoryStore()
-	exec := a2a.New(prompter, store, a2a.ModeChat, nil)
+	exec := a2a.New(prompter, store, a2a.ModeChat, nil, memory.NoOp{})
 
 	queue := &captureQueue{}
 	reqCtx := makeReqCtx("ctx-3", "hello")
@@ -186,7 +187,7 @@ func TestExecutor_SuccessfulTurn(t *testing.T) {
 		},
 	}
 	store := session.NewMemoryStore()
-	exec := a2a.New(prompter, store, a2a.ModeChat, nil)
+	exec := a2a.New(prompter, store, a2a.ModeChat, nil, memory.NoOp{})
 
 	queue := &captureQueue{}
 	reqCtx := makeReqCtx("ctx-4", "What is the answer?")
@@ -231,7 +232,7 @@ func TestExecutor_ConcurrentContextRejected(t *testing.T) {
 	blocker := &blockingPrompter{fakePrompter: prompter, block: blocked}
 
 	store := session.NewMemoryStore()
-	exec := a2a.New(blocker, store, a2a.ModeChat, nil)
+	exec := a2a.New(blocker, store, a2a.ModeChat, nil, memory.NoOp{})
 
 	// First request: holds the lock.
 	ctx1, cancel1 := context.WithCancel(t.Context())
@@ -269,7 +270,7 @@ func TestExecutor_ConcurrentContextRejected(t *testing.T) {
 func TestExecutor_Cancel(t *testing.T) {
 	prompter := &fakePrompter{}
 	store := session.NewMemoryStore()
-	exec := a2a.New(prompter, store, a2a.ModeChat, nil)
+	exec := a2a.New(prompter, store, a2a.ModeChat, nil, memory.NoOp{})
 
 	queue := &captureQueue{}
 	reqCtx := makeReqCtx("ctx-cancel", "")
@@ -319,7 +320,7 @@ func TestExecutor_AgentModeResume(t *testing.T) {
 		},
 	}
 	store := session.NewMemoryStore()
-	exec := a2a.New(prompter, store, a2a.ModeAgent, nil)
+	exec := a2a.New(prompter, store, a2a.ModeAgent, nil, memory.NoOp{})
 
 	// First turn — no prior session.
 	q1 := &captureQueue{}

--- a/pkg/a2a/executor_test.go
+++ b/pkg/a2a/executor_test.go
@@ -473,3 +473,78 @@ func TestExecutor_AgentModeResume(t *testing.T) {
 	assert.Empty(t, opts2.SessionID, "second turn must not pass --session-id")
 	assert.True(t, opts2.SaveSession, "second turn must set SaveSession")
 }
+
+// staleResumePrompter simulates a subprocess that fails on the first (resume)
+// call but succeeds on the retry (fresh session). Used to test stale-resume
+// detection after pod restart with emptyDir workspace.
+type staleResumePrompter struct {
+	*fakePrompter
+	calls int
+}
+
+func (p *staleResumePrompter) RunWithOptions(_ context.Context, _ string, opts *claude.RunOptions) (<-chan claude.StreamMessage, error) {
+	p.calls++
+	p.fakePrompter.capturedOpts = append(p.fakePrompter.capturedOpts, opts)
+	var msgs []claude.StreamMessage
+	if p.calls >= 2 {
+		// Retry succeeds: emit session + result.
+		msgs = []claude.StreamMessage{
+			{Type: claude.MessageTypeSystem, SessionID: "new-session-id"},
+			{Type: claude.MessageTypeResult, Result: "retry succeeded"},
+		}
+	}
+	// First call: empty channel — no session ID emitted, simulates failed resume.
+	ch := make(chan claude.StreamMessage, len(msgs)+1)
+	for _, m := range msgs {
+		ch <- m
+	}
+	close(ch)
+	return ch, nil
+}
+
+func (p *staleResumePrompter) Status() claude.StatusInfo {
+	if p.calls <= 1 {
+		// After first (failed) call: subprocess error.
+		return claude.StatusInfo{Status: claude.ProcessStatusError, ErrorMessage: "exit status 1"}
+	}
+	return claude.StatusInfo{Status: claude.ProcessStatusIdle}
+}
+
+// TestExecutor_StaleResumeRetry verifies that when --resume fails (session file
+// gone after pod restart), the executor retries with a fresh session and the
+// turn completes rather than failing.
+func TestExecutor_StaleResumeRetry(t *testing.T) {
+	const oldSession = "old-session-id"
+
+	inner := &fakePrompter{}
+	prompter := &staleResumePrompter{fakePrompter: inner}
+
+	store := session.NewMemoryStore()
+	// Pre-populate the store with the stale session binding (as Postgres would
+	// have it after a pod restart with emptyDir workspace).
+	require.NoError(t, store.BindSession(t.Context(), "ctx-stale", oldSession))
+
+	exec := a2a.New(prompter, store, a2a.ModeAgent, nil, memory.NoOp{})
+
+	queue := &captureQueue{}
+	err := exec.Execute(t.Context(), makeReqCtx("ctx-stale", "hello after restart"), queue)
+	require.NoError(t, err)
+
+	// Turn must succeed, not fail.
+	last := queue.events[len(queue.events)-1]
+	statusEv, ok := last.(*a2asdk.TaskStatusUpdateEvent)
+	require.True(t, ok)
+	assert.Equal(t, a2asdk.TaskStateCompleted, statusEv.Status.State, "stale resume should retry and complete")
+	assert.True(t, statusEv.Final)
+
+	// Two RunWithOptions calls: first with Resume (stale), second without.
+	require.Len(t, prompter.capturedOpts, 2, "expected exactly two RunWithOptions calls")
+	assert.Equal(t, oldSession, prompter.capturedOpts[0].Resume, "first call must use --resume with the stale ID")
+	assert.Empty(t, prompter.capturedOpts[1].Resume, "retry call must not pass --resume")
+	assert.Equal(t, "stale", prompter.capturedOpts[1].SessionID, "retry must seed session ID from contextID")
+
+	// After retry the store must hold the NEW session ID.
+	sessID, err := store.SessionID(t.Context(), "ctx-stale")
+	require.NoError(t, err)
+	assert.Equal(t, "new-session-id", sessID, "stale Postgres binding must be overwritten after retry")
+}

--- a/pkg/claude/options.go
+++ b/pkg/claude/options.go
@@ -131,6 +131,12 @@ type Options struct {
 	// attempt. Each subsequent attempt doubles the duration.
 	// Defaults to 2s.
 	RetryBaseBackoff time.Duration
+
+	// ResumeSessionID, when set, passes --resume <id> at PersistentProcess
+	// startup. Use this to continue a named session after a pod restart without
+	// requiring a first-turn warm-up. Only applied via PersistentArgs; the
+	// single-shot Process uses RunOptions.Resume instead.
+	ResumeSessionID string
 }
 
 // Permission modes recognised by the Claude Code CLI.
@@ -374,6 +380,9 @@ func (o Options) args() []string {
 // It shares the base arguments with single-shot mode but adds --input-format stream-json
 // and --replay-user-messages, and omits session management flags since the persistent
 // subprocess maintains a single long-running session.
+//
+// When ResumeSessionID is set, --resume <id> is appended so the subprocess
+// continues an existing session from startup (e.g. after a pod restart).
 func (o Options) PersistentArgs() []string {
 	args := []string{
 		"--print",
@@ -384,6 +393,9 @@ func (o Options) PersistentArgs() []string {
 		"--include-partial-messages",
 	}
 	args = append(args, o.baseArgs()...)
+	if o.ResumeSessionID != "" {
+		args = append(args, "--resume", o.ResumeSessionID)
+	}
 	return args
 }
 

--- a/pkg/claude/process.go
+++ b/pkg/claude/process.go
@@ -180,6 +180,7 @@ func (p *Process) RunWithOptions(ctx context.Context, prompt string, runOpts *Ru
 	}
 	p.status = ProcessStatusStarting
 	p.lastError = ""
+	p.sessionID = ""
 	// Preserve liveMessages and messageCount across turns so that
 	// the MCP messages tool returns the full conversation history
 	// and message_count accumulates rather than resetting (#171).

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -94,6 +94,13 @@ type ClaudeConfig struct {
 	// agent: single-shot Process subprocess with --no-session-persistence.
 	// chat: PersistentProcess subprocess with sessions saved to disk.
 	Mode string `yaml:"mode"`
+
+	// RetryMaxAttempts is the maximum subprocess restart attempts by the watchdog.
+	// 0 means use the default (3).
+	RetryMaxAttempts int `yaml:"retryMaxAttempts"`
+	// RetryBaseBackoff is the initial backoff before the first restart (e.g. "2s").
+	// Each subsequent attempt doubles the duration. Empty means use the default (2s).
+	RetryBaseBackoff string `yaml:"retryBaseBackoff"`
 }
 
 // ServerConfig holds settings consumed by the klaus server process itself
@@ -226,6 +233,8 @@ func applyEnvOverrides(cfg *Config) {
 	envOverrideString(&cfg.Claude.Agents, "CLAUDE_AGENTS")
 	envOverrideString(&cfg.Claude.ActiveAgent, "CLAUDE_ACTIVE_AGENT")
 	envOverrideString(&cfg.Claude.Mode, "CLAUDE_MODE")
+	envOverrideInt(&cfg.Claude.RetryMaxAttempts, "KLAUS_RETRY_MAX_ATTEMPTS")
+	envOverrideString(&cfg.Claude.RetryBaseBackoff, "KLAUS_RETRY_BASE_BACKOFF")
 
 	// Server settings.
 	envOverrideString(&cfg.Server.Port, "PORT")

--- a/pkg/kagentapi/auth.go
+++ b/pkg/kagentapi/auth.go
@@ -1,0 +1,50 @@
+package kagentapi
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+)
+
+type authContextKey struct{}
+
+// AuthInfo carries the caller's OIDC identity extracted from an incoming HTTP
+// request. It is stored in context by the auth-extract middleware and read by
+// PushEvent to authenticate against the kagent controller (trusted-proxy mode
+// requires a Bearer JWT + the user sub via X-User-Id).
+type AuthInfo struct {
+	BearerToken string
+	UserSub     string
+}
+
+// WithAuthInfo stores info in ctx.
+func WithAuthInfo(ctx context.Context, info AuthInfo) context.Context {
+	return context.WithValue(ctx, authContextKey{}, info)
+}
+
+// AuthInfoFromContext retrieves AuthInfo from ctx. Returns zero value if none.
+func AuthInfoFromContext(ctx context.Context) AuthInfo {
+	v, _ := ctx.Value(authContextKey{}).(AuthInfo)
+	return v
+}
+
+// ParseJWTSub decodes a JWT without signature verification and returns the
+// "sub" claim. Returns "" if the token is not a valid three-part JWT or has
+// no sub.
+func ParseJWTSub(token string) string {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return ""
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return ""
+	}
+	var claims map[string]any
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return ""
+	}
+	sub, _ := claims["sub"].(string)
+	return sub
+}

--- a/pkg/kagentapi/client.go
+++ b/pkg/kagentapi/client.go
@@ -48,6 +48,21 @@ type SessionEvent struct {
 	Data string `json:"data"`
 }
 
+// a2aTask mirrors the subset of trpc-a2a-go protocol.Task that the kagent
+// controller's POST /api/tasks endpoint persists. The full SDK is not imported
+// to avoid a cross-module dependency.
+type a2aTask struct {
+	Kind      string        `json:"kind"`
+	ID        string        `json:"id"`
+	ContextID string        `json:"contextId"`
+	Status    a2aTaskStatus `json:"status"`
+	History   []a2aMessage  `json:"history,omitempty"`
+}
+
+type a2aTaskStatus struct {
+	State string `json:"state"`
+}
+
 // NewSessionEvent builds a SessionEvent for the given role ("user" or "agent")
 // and plain-text content. id should be unique per event (e.g. a UUID).
 func NewSessionEvent(id, role, text string) SessionEvent {
@@ -132,5 +147,65 @@ func (c *Client) PushEvent(ctx context.Context, sessionID string, event SessionE
 
 	if resp.StatusCode >= 400 {
 		c.log.WarnContext(ctx, "kagentapi: push event non-2xx", "status", resp.StatusCode, "session_id", sessionID)
+	}
+}
+
+// StoreTask persists a completed turn as an A2A task in kagent's task store.
+// This is required for BYO agents because kagent's A2A passthrough proxy does
+// not persist tasks itself — the task store is only populated by declarative
+// (Python ADK) agents. Without this call, GET /api/sessions/{id}/tasks always
+// returns empty and the kagent UI shows no conversation history on reload.
+//
+// taskID must be unique per task (e.g. a UUID). contextID is the A2A context
+// ID that matches the kagent session. userText and agentText are the turn.
+func (c *Client) StoreTask(ctx context.Context, taskID, contextID, userText, agentText string) {
+	if !c.Enabled() {
+		return
+	}
+
+	task := a2aTask{
+		Kind:      "task",
+		ID:        taskID,
+		ContextID: contextID,
+		Status:    a2aTaskStatus{State: "completed"},
+		History: []a2aMessage{
+			{Kind: "message", MessageID: taskID + "-user", Role: "user",
+				Parts: []a2aPart{{Kind: "text", Text: userText}}},
+			{Kind: "message", MessageID: taskID + "-agent", Role: "agent",
+				Parts: []a2aPart{{Kind: "text", Text: agentText}}},
+		},
+	}
+
+	body, err := json.Marshal(task)
+	if err != nil {
+		c.log.ErrorContext(ctx, "kagentapi: marshal task", "err", err)
+		return
+	}
+
+	url := fmt.Sprintf("%s/api/tasks", c.endpoint)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		c.log.ErrorContext(ctx, "kagentapi: build task request", "err", err, "task_id", taskID)
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	info := AuthInfoFromContext(ctx)
+	if info.BearerToken != "" {
+		req.Header.Set("Authorization", "Bearer "+info.BearerToken)
+	}
+	if info.UserSub != "" {
+		req.Header.Set("X-User-Id", info.UserSub)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		c.log.WarnContext(ctx, "kagentapi: store task failed", "err", err, "task_id", taskID)
+		return
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode >= 400 {
+		c.log.WarnContext(ctx, "kagentapi: store task non-2xx", "status", resp.StatusCode, "task_id", taskID)
 	}
 }

--- a/pkg/kagentapi/client.go
+++ b/pkg/kagentapi/client.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	defaultTimeout   = 5 * time.Second
+	defaultTimeout    = 5 * time.Second
 	envKagentAgentRef = "KAGENT_AGENT_REF"
 )
 

--- a/pkg/kagentapi/client.go
+++ b/pkg/kagentapi/client.go
@@ -4,6 +4,9 @@
 //
 // Env: KAGENT_API_ENDPOINT — base URL (e.g. http://kagent-controller.kagent.svc).
 // When unset, all operations are no-ops.
+//
+// Env: KAGENT_AGENT_REF — namespace/name of this agent as registered in kagent
+// (e.g. "kagent/klaud-coding"). When set, sent as X-Agent-Name on push requests.
 package kagentapi
 
 import (
@@ -13,16 +16,49 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"os"
 	"time"
 )
 
-const defaultTimeout = 5 * time.Second
+const (
+	defaultTimeout   = 5 * time.Second
+	envKagentAgentRef = "KAGENT_AGENT_REF"
+)
+
+// a2aMessage is the JSON structure stored in Event.Data — a trpc-a2a-go
+// protocol.Message. Defined here so pkg/kagentapi has no dependency on the
+// trpc SDK.
+type a2aMessage struct {
+	Kind      string    `json:"kind"`
+	MessageID string    `json:"messageId"`
+	Role      string    `json:"role"`
+	Parts     []a2aPart `json:"parts"`
+}
+
+type a2aPart struct {
+	Kind string `json:"kind"`
+	Text string `json:"text"`
+}
 
 // SessionEvent is a single turn event sent to the kagent session history API.
 // POST /api/sessions/{id}/events
+// Data is a JSON-serialized A2A protocol.Message (see NewSessionEvent).
 type SessionEvent struct {
-	Role    string `json:"role"`
-	Content string `json:"content"`
+	ID   string `json:"id"`
+	Data string `json:"data"`
+}
+
+// NewSessionEvent builds a SessionEvent for the given role ("user" or "agent")
+// and plain-text content. id should be unique per event (e.g. a UUID).
+func NewSessionEvent(id, role, text string) SessionEvent {
+	msg := a2aMessage{
+		Kind:      "message",
+		MessageID: id,
+		Role:      role,
+		Parts:     []a2aPart{{Kind: "text", Text: text}},
+	}
+	data, _ := json.Marshal(msg)
+	return SessionEvent{ID: id, Data: string(data)}
 }
 
 // Client pushes session turn events to the kagent UI. It is safe for
@@ -50,6 +86,11 @@ func (c *Client) Enabled() bool {
 
 // PushEvent sends a single session event to the kagent controller.
 // It is a best-effort operation; any error is logged and discarded.
+//
+// Auth: the kagent controller runs in trusted-proxy mode and requires a Bearer
+// JWT + the user sub via X-User-Id. Auth is read from ctx (set by the
+// extractCallerAuth middleware in pkg/server). Without valid auth the push
+// returns 401 and is silently discarded.
 func (c *Client) PushEvent(ctx context.Context, sessionID string, event SessionEvent) {
 	if !c.Enabled() {
 		return
@@ -68,8 +109,19 @@ func (c *Client) PushEvent(ctx context.Context, sessionID string, event SessionE
 		return
 	}
 	req.Header.Set("Content-Type", "application/json")
-	// kagent controller uses internal-trust auth via X-User-ID.
-	req.Header.Set("X-User-ID", "klaus")
+
+	// Forward the caller's OIDC identity so the kagent controller can locate
+	// the session (which is owned by the user, not the agent pod).
+	info := AuthInfoFromContext(ctx)
+	if info.BearerToken != "" {
+		req.Header.Set("Authorization", "Bearer "+info.BearerToken)
+	}
+	if info.UserSub != "" {
+		req.Header.Set("X-User-Id", info.UserSub)
+	}
+	if agentRef := os.Getenv(envKagentAgentRef); agentRef != "" {
+		req.Header.Set("X-Agent-Name", agentRef)
+	}
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {

--- a/pkg/kagentapi/client_test.go
+++ b/pkg/kagentapi/client_test.go
@@ -17,18 +17,19 @@ func TestClient_Disabled(t *testing.T) {
 	c := kagentapi.New("")
 	assert.False(t, c.Enabled())
 	// Must not panic or make any requests.
-	c.PushEvent(t.Context(), "sess-1", kagentapi.SessionEvent{Role: "user", Content: "hello"})
+	c.PushEvent(t.Context(), "sess-1", kagentapi.NewSessionEvent("id-1", "user", "hello"))
 }
 
 func TestClient_PushEvent(t *testing.T) {
 	var received []kagentapi.SessionEvent
 	var gotSessionID string
+	var gotAuthHeader string
 	var gotUserID string
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Expect POST /api/sessions/{id}/events.
 		gotSessionID = r.URL.Path
-		gotUserID = r.Header.Get("X-User-ID")
+		gotAuthHeader = r.Header.Get("Authorization")
+		gotUserID = r.Header.Get("X-User-Id")
 
 		body, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
@@ -44,15 +45,21 @@ func TestClient_PushEvent(t *testing.T) {
 	c := kagentapi.New(srv.URL)
 	require.True(t, c.Enabled())
 
-	c.PushEvent(t.Context(), "sess-abc", kagentapi.SessionEvent{Role: "user", Content: "what is 2+2?"})
+	// Inject auth via context.
+	ctx := kagentapi.WithAuthInfo(t.Context(), kagentapi.AuthInfo{
+		BearerToken: "tok123",
+		UserSub:     "user@example.com",
+	})
 
-	// PushEvent is synchronous (the goroutine in the real path is for
-	// the executor, not the client itself).
+	event := kagentapi.NewSessionEvent("msg-1", "user", "what is 2+2?")
+	c.PushEvent(ctx, "sess-abc", event)
+
 	require.Len(t, received, 1)
-	assert.Equal(t, "user", received[0].Role)
-	assert.Equal(t, "what is 2+2?", received[0].Content)
+	assert.Equal(t, event.ID, received[0].ID)
+	assert.Equal(t, event.Data, received[0].Data)
 	assert.Equal(t, "/api/sessions/sess-abc/events", gotSessionID)
-	assert.Equal(t, "klaus", gotUserID)
+	assert.Equal(t, "Bearer tok123", gotAuthHeader)
+	assert.Equal(t, "user@example.com", gotUserID)
 }
 
 func TestClient_PushEvent_Non2xx(t *testing.T) {
@@ -63,5 +70,5 @@ func TestClient_PushEvent_Non2xx(t *testing.T) {
 
 	c := kagentapi.New(srv.URL)
 	// Should not panic or return error; failure is logged only.
-	c.PushEvent(t.Context(), "sess-xyz", kagentapi.SessionEvent{Role: "assistant", Content: "reply"})
+	c.PushEvent(t.Context(), "sess-xyz", kagentapi.NewSessionEvent("msg-2", "agent", "reply"))
 }

--- a/pkg/mcp/tools.go
+++ b/pkg/mcp/tools.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -150,6 +151,9 @@ func promptTool(serverCtx context.Context, process claudepkg.Prompter) server.Se
 			// outlives the MCP request but is cancelled on shutdown.
 			if err := process.Submit(serverCtx, message, &runOpts); err != nil {
 				metrics.PromptsTotal.WithLabelValues("error", "async").Inc()
+				if errors.Is(err, claudepkg.ErrBusy) {
+					return mcp.NewToolResultError("agent is busy: another prompt is already running"), nil
+				}
 				return mcp.NewToolResultError(fmt.Sprintf("failed to start task: %v", err)), nil
 			}
 
@@ -184,6 +188,9 @@ func promptTool(serverCtx context.Context, process claudepkg.Prompter) server.Se
 		ch, err := process.RunWithOptions(ctx, message, &runOpts)
 		if err != nil {
 			metrics.PromptsTotal.WithLabelValues("error", "blocking").Inc()
+			if errors.Is(err, claudepkg.ErrBusy) {
+				return mcp.NewToolResultError("agent is busy: another prompt is already running"), nil
+			}
 			return mcp.NewToolResultError(fmt.Sprintf("claude execution failed: %v", err)), nil
 		}
 

--- a/pkg/mcp/tools_test.go
+++ b/pkg/mcp/tools_test.go
@@ -662,6 +662,59 @@ func TestPromptTool_BlockingRunError(t *testing.T) {
 	}
 }
 
+func TestPromptTool_NonBlockingErrBusy(t *testing.T) {
+	mock := &mockPrompter{runErr: claudepkg.ErrBusy}
+	tools := buildToolMap(mock)
+	handler := tools["prompt"]
+
+	result, err := handler(context.Background(), newCallToolRequest("prompt", map[string]any{
+		"message": "Hello",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.IsError {
+		t.Error("expected error result for ErrBusy")
+	}
+	if len(result.Content) == 0 {
+		t.Fatal("expected non-empty content")
+	}
+	text, ok := result.Content[0].(mcp.TextContent)
+	if !ok {
+		t.Fatalf("expected TextContent, got %T", result.Content[0])
+	}
+	if text.Text != "agent is busy: another prompt is already running" {
+		t.Errorf("unexpected message: %q", text.Text)
+	}
+}
+
+func TestPromptTool_BlockingErrBusy(t *testing.T) {
+	mock := &mockPrompter{runErr: claudepkg.ErrBusy}
+	tools := buildToolMap(mock)
+	handler := tools["prompt"]
+
+	result, err := handler(context.Background(), newCallToolRequest("prompt", map[string]any{
+		"message":  "Hello",
+		"blocking": true,
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.IsError {
+		t.Error("expected error result for ErrBusy")
+	}
+	if len(result.Content) == 0 {
+		t.Fatal("expected non-empty content")
+	}
+	text, ok := result.Content[0].(mcp.TextContent)
+	if !ok {
+		t.Fatalf("expected TextContent, got %T", result.Content[0])
+	}
+	if text.Text != "agent is busy: another prompt is already running" {
+		t.Errorf("unexpected message: %q", text.Text)
+	}
+}
+
 // --- Status tool tests ---
 
 func TestStatusTool(t *testing.T) {

--- a/pkg/memory/client.go
+++ b/pkg/memory/client.go
@@ -11,9 +11,9 @@
 //
 // Required env for kagent backend:
 //   - KAGENT_MEMORY_ENDPOINT — kagent controller base URL
-//   - KLAUD_EMBEDDING_ENDPOINT — OpenAI-compatible embedding base URL (default: https://api.openai.com/v1)
-//   - KLAUD_EMBEDDING_MODEL — embedding model name (e.g. text-embedding-3-small)
-//   - KLAUD_EMBEDDING_API_KEY — API key (omit for unauthenticated vLLM endpoints)
+//   - KLAUS_EMBEDDING_ENDPOINT — OpenAI-compatible embedding base URL (default: https://api.openai.com/v1)
+//   - KLAUS_EMBEDDING_MODEL — embedding model name (e.g. text-embedding-3-small)
+//   - KLAUS_EMBEDDING_API_KEY — API key (omit for unauthenticated vLLM endpoints)
 package memory
 
 import (

--- a/pkg/memory/client.go
+++ b/pkg/memory/client.go
@@ -1,15 +1,19 @@
 // Package memory defines the interface for retrieving and storing conversation
-// memory chunks. The memory layer injects relevant past context into the system
-// prompt before each claude invocation and persists new turns for future recall.
+// memory chunks across sessions. Before each turn, relevant chunks are prepended
+// to the user prompt; after each turn, user and assistant text are stored for
+// future recall.
 //
-// The default implementation is a no-op; the kagent-backed implementation
-// (using POST /api/memories/sessions and POST /api/memories/search) is a
-// separate follow-up once the embedding model used by kagent is confirmed.
+// Implementations:
+//   - NoOp: discard all writes, return empty results (default when env unset)
+//   - KagentClient: kagent pgvector API (POST /api/memories/sessions and
+//     POST /api/memories/search). Caller generates 768-dim float32 vectors
+//     via an OpenAI-compatible embedding endpoint (see pkg/memory/embedding.go).
 //
-// Open item: kagent requires exactly 768-dimensional float32 embeddings.
-// The embedding model must match what kagent's ADK uses, otherwise cosine
-// search returns garbage. Do not implement the kagent client until the
-// embedding model is verified (check kagent source or klausctl embed helper).
+// Required env for kagent backend:
+//   - KAGENT_MEMORY_ENDPOINT — kagent controller base URL
+//   - KLAUD_EMBEDDING_ENDPOINT — OpenAI-compatible embedding base URL (default: https://api.openai.com/v1)
+//   - KLAUD_EMBEDDING_MODEL — embedding model name (e.g. text-embedding-3-small)
+//   - KLAUD_EMBEDDING_API_KEY — API key (omit for unauthenticated vLLM endpoints)
 package memory
 
 import (

--- a/pkg/memory/embedding.go
+++ b/pkg/memory/embedding.go
@@ -25,14 +25,14 @@ type embeddingClient struct {
 }
 
 func newEmbeddingClientFromEnv() *embeddingClient {
-	endpoint := os.Getenv("KLAUD_EMBEDDING_ENDPOINT")
+	endpoint := os.Getenv("KLAUS_EMBEDDING_ENDPOINT")
 	if endpoint == "" {
 		endpoint = "https://api.openai.com/v1"
 	}
 	return &embeddingClient{
 		endpoint:   endpoint,
-		model:      os.Getenv("KLAUD_EMBEDDING_MODEL"),
-		apiKey:     os.Getenv("KLAUD_EMBEDDING_API_KEY"),
+		model:      os.Getenv("KLAUS_EMBEDDING_MODEL"),
+		apiKey:     os.Getenv("KLAUS_EMBEDDING_API_KEY"),
 		httpClient: &http.Client{Timeout: 30 * time.Second},
 	}
 }

--- a/pkg/memory/embedding.go
+++ b/pkg/memory/embedding.go
@@ -1,0 +1,107 @@
+package memory
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"net/http"
+	"os"
+	"time"
+)
+
+const embeddingDim = 768
+
+// embeddingClient calls an OpenAI-compatible embedding endpoint.
+// Compatible with OpenAI, vLLM, Ollama (via its /v1 proxy), and any other
+// OpenAI-spec embedding server. Returns exactly 768-dim float32 vectors
+// (truncated if the model produces more, with L2 re-normalization).
+type embeddingClient struct {
+	endpoint   string
+	model      string
+	apiKey     string
+	httpClient *http.Client
+}
+
+func newEmbeddingClientFromEnv() *embeddingClient {
+	endpoint := os.Getenv("KLAUD_EMBEDDING_ENDPOINT")
+	if endpoint == "" {
+		endpoint = "https://api.openai.com/v1"
+	}
+	return &embeddingClient{
+		endpoint:   endpoint,
+		model:      os.Getenv("KLAUD_EMBEDDING_MODEL"),
+		apiKey:     os.Getenv("KLAUD_EMBEDDING_API_KEY"),
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+func (c *embeddingClient) enabled() bool {
+	return c.model != ""
+}
+
+func (c *embeddingClient) embed(ctx context.Context, text string) ([]float32, error) {
+	body, err := json.Marshal(map[string]any{
+		"model": c.model,
+		"input": []string{text},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal embedding request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpoint+"/embeddings", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("build embedding request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if c.apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("embedding request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("embedding API returned HTTP %d", resp.StatusCode)
+	}
+
+	var result struct {
+		Data []struct {
+			Embedding []float32 `json:"embedding"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decode embedding response: %w", err)
+	}
+	if len(result.Data) == 0 || len(result.Data[0].Embedding) == 0 {
+		return nil, fmt.Errorf("empty embedding response from %s", c.endpoint)
+	}
+
+	return truncateAndNormalize(result.Data[0].Embedding, embeddingDim), nil
+}
+
+// truncateAndNormalize truncates vec to dim elements and re-applies L2 normalization.
+// Truncation without re-normalization produces a vector that is no longer unit-length,
+// which degrades cosine similarity scores in the vector store.
+func truncateAndNormalize(vec []float32, dim int) []float32 {
+	if len(vec) > dim {
+		vec = vec[:dim]
+	}
+	var sum float64
+	for _, v := range vec {
+		sum += float64(v) * float64(v)
+	}
+	norm := float32(math.Sqrt(sum))
+	if norm == 0 {
+		return vec
+	}
+	out := make([]float32, len(vec))
+	for i, v := range vec {
+		out[i] = v / norm
+	}
+	return out
+}

--- a/pkg/memory/embedding_test.go
+++ b/pkg/memory/embedding_test.go
@@ -1,0 +1,60 @@
+package memory
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTruncateAndNormalize(t *testing.T) {
+	t.Run("exact length is re-normalized", func(t *testing.T) {
+		vec := []float32{3, 4}
+		got := truncateAndNormalize(vec, 2)
+		assertUnitLength(t, got)
+		assert.InDelta(t, 0.6, got[0], 1e-6)
+		assert.InDelta(t, 0.8, got[1], 1e-6)
+	})
+
+	t.Run("longer vector is truncated then re-normalized", func(t *testing.T) {
+		// vec has 4 elements, dim=2; truncate to [3,4] then normalize.
+		vec := []float32{3, 4, 9, 9}
+		got := truncateAndNormalize(vec, 2)
+		assert.Len(t, got, 2)
+		assertUnitLength(t, got)
+	})
+
+	t.Run("shorter vector is unchanged in length", func(t *testing.T) {
+		vec := []float32{1, 0}
+		got := truncateAndNormalize(vec, 768)
+		assert.Len(t, got, 2)
+		assertUnitLength(t, got)
+	})
+
+	t.Run("zero-norm vector returned unchanged", func(t *testing.T) {
+		vec := []float32{0, 0, 0}
+		got := truncateAndNormalize(vec, 3)
+		assert.Equal(t, []float32{0, 0, 0}, got)
+	})
+
+	t.Run("768-dim vector is unit-length after normalize", func(t *testing.T) {
+		vec := make([]float32, 768)
+		for i := range vec {
+			vec[i] = 1
+		}
+		got := truncateAndNormalize(vec, 768)
+		assert.Len(t, got, 768)
+		assertUnitLength(t, got)
+	})
+}
+
+// assertUnitLength checks that the L2 norm of vec is within floating-point
+// tolerance of 1.0.
+func assertUnitLength(t *testing.T, vec []float32) {
+	t.Helper()
+	var sum float64
+	for _, v := range vec {
+		sum += float64(v) * float64(v)
+	}
+	assert.InDelta(t, 1.0, math.Sqrt(sum), 1e-5)
+}

--- a/pkg/memory/factory.go
+++ b/pkg/memory/factory.go
@@ -1,0 +1,23 @@
+package memory
+
+import "os"
+
+// New returns a memory Client configured from environment variables.
+//
+// Returns NoOp when:
+//   - KAGENT_MEMORY_ENDPOINT is unset (no store configured)
+//   - KLAUD_EMBEDDING_MODEL is unset (vectors cannot be generated)
+//
+// When both are set, returns a KagentClient that stores and searches
+// conversation memory via the kagent pgvector API.
+func New() Client {
+	endpoint := os.Getenv("KAGENT_MEMORY_ENDPOINT")
+	if endpoint == "" {
+		return NoOp{}
+	}
+	client := newKagentClientFromEnv(endpoint)
+	if !client.embedder.enabled() {
+		return NoOp{}
+	}
+	return client
+}

--- a/pkg/memory/factory.go
+++ b/pkg/memory/factory.go
@@ -6,7 +6,7 @@ import "os"
 //
 // Returns NoOp when:
 //   - KAGENT_MEMORY_ENDPOINT is unset (no store configured)
-//   - KLAUD_EMBEDDING_MODEL is unset (vectors cannot be generated)
+//   - KLAUS_EMBEDDING_MODEL is unset (vectors cannot be generated)
 //
 // When both are set, returns a KagentClient that stores and searches
 // conversation memory via the kagent pgvector API.

--- a/pkg/memory/factory_test.go
+++ b/pkg/memory/factory_test.go
@@ -1,0 +1,111 @@
+package memory_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/giantswarm/klaus/pkg/memory"
+)
+
+// TestNew_NoOp verifies that factory.New returns a NoOp when the required env
+// vars are absent, without attempting any network calls.
+func TestNew_NoOp(t *testing.T) {
+	t.Run("no endpoint", func(t *testing.T) {
+		t.Setenv("KAGENT_MEMORY_ENDPOINT", "")
+		t.Setenv("KLAUS_EMBEDDING_MODEL", "text-embedding-3-small")
+		c := memory.New()
+		_, ok := c.(memory.NoOp)
+		assert.True(t, ok, "expected NoOp when KAGENT_MEMORY_ENDPOINT is unset")
+	})
+
+	t.Run("no embedding model", func(t *testing.T) {
+		t.Setenv("KAGENT_MEMORY_ENDPOINT", "http://localhost:9999")
+		t.Setenv("KLAUS_EMBEDDING_MODEL", "")
+		c := memory.New()
+		_, ok := c.(memory.NoOp)
+		assert.True(t, ok, "expected NoOp when KLAUS_EMBEDDING_MODEL is unset")
+	})
+
+	t.Run("both set returns non-NoOp", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		t.Cleanup(srv.Close)
+		t.Setenv("KAGENT_MEMORY_ENDPOINT", srv.URL)
+		t.Setenv("KLAUS_EMBEDDING_MODEL", "text-embedding-3-small")
+		c := memory.New()
+		_, ok := c.(memory.NoOp)
+		assert.False(t, ok, "expected non-NoOp when both vars are set")
+	})
+}
+
+// TestKagentClient_RetrieveStore exercises the full HTTP path of KagentClient
+// using an httptest server for both the embedding endpoint and the kagent API.
+func TestKagentClient_RetrieveStore(t *testing.T) {
+	// Embedding server: returns a 768-dim unit vector.
+	embeddingSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		vec := make([]float32, 768)
+		vec[0] = 1.0
+		resp := map[string]any{
+			"data": []map[string]any{
+				{"embedding": vec},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	t.Cleanup(embeddingSrv.Close)
+
+	// kagent API server.
+	var searchBody, storeBody []byte
+	var xUserIDOnSearch, xUserIDOnStore string
+	kagentSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/memories/search":
+			xUserIDOnSearch = r.Header.Get("X-User-ID")
+			json.NewDecoder(r.Body).Decode(&searchBody) //nolint:errcheck
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode([]map[string]any{
+				{"id": "a1", "content": "remembered text", "score": 0.85},
+			})
+		case "/api/memories/sessions":
+			xUserIDOnStore = r.Header.Get("X-User-ID")
+			json.NewDecoder(r.Body).Decode(&storeBody) //nolint:errcheck
+			w.WriteHeader(http.StatusOK)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(kagentSrv.Close)
+
+	t.Setenv("KAGENT_MEMORY_ENDPOINT", kagentSrv.URL)
+	t.Setenv("KAGENT_MEMORY_USER_ID", "test-user")
+	t.Setenv("KAGENT_MEMORY_AGENT_NAME", "test-agent")
+	t.Setenv("KLAUS_EMBEDDING_ENDPOINT", embeddingSrv.URL+"/v1")
+	t.Setenv("KLAUS_EMBEDDING_MODEL", "test-model")
+	t.Setenv("KLAUS_EMBEDDING_API_KEY", "")
+
+	client := memory.New()
+	_, isNoOp := client.(memory.NoOp)
+	require.False(t, isNoOp)
+
+	t.Run("Retrieve returns chunks", func(t *testing.T) {
+		chunks, err := client.Retrieve(t.Context(), "ctx-1", "what did we discuss?", 5)
+		require.NoError(t, err)
+		require.Len(t, chunks, 1)
+		assert.Equal(t, "remembered text", chunks[0].Content)
+		assert.InDelta(t, 0.85, chunks[0].Score, 1e-5)
+		assert.Equal(t, "test-user", xUserIDOnSearch, "X-User-ID must use configured user ID, not hardcoded")
+	})
+
+	t.Run("Store sends content to kagent", func(t *testing.T) {
+		err := client.Store(t.Context(), "ctx-1", "user", "hello world")
+		require.NoError(t, err)
+		assert.Equal(t, "test-user", xUserIDOnStore, "X-User-ID must use configured user ID, not hardcoded")
+	})
+}

--- a/pkg/memory/kagent.go
+++ b/pkg/memory/kagent.go
@@ -1,0 +1,160 @@
+package memory
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"time"
+)
+
+// KagentClient implements Client against the kagent pgvector memory API.
+// All vectors are generated locally by embeddingClient — the kagent controller
+// does not embed; it stores and searches raw float32 vectors supplied by the caller.
+//
+// API (internal, undocumented, may change between kagent minors):
+//
+//	POST /api/memories/sessions — store a content+vector pair
+//	POST /api/memories/search   — vector similarity search
+//
+// Both endpoints require X-User-ID: <any non-empty value> for internal-trust auth.
+type KagentClient struct {
+	endpoint   string
+	agentName  string
+	userID     string
+	embedder   *embeddingClient
+	httpClient *http.Client
+	log        *slog.Logger
+}
+
+var _ Client = (*KagentClient)(nil)
+
+func newKagentClientFromEnv(endpoint string) *KagentClient {
+	return &KagentClient{
+		endpoint:   endpoint,
+		agentName:  kagentEnvOrDefault("KAGENT_MEMORY_AGENT_NAME", "klaus"),
+		userID:     kagentEnvOrDefault("KAGENT_MEMORY_USER_ID", "default"),
+		embedder:   newEmbeddingClientFromEnv(),
+		httpClient: &http.Client{Timeout: 10 * time.Second},
+		log:        slog.Default().With("component", "memory.kagent"),
+	}
+}
+
+func kagentEnvOrDefault(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+type kagentAddRequest struct {
+	AgentName string    `json:"agent_name"`
+	UserID    string    `json:"user_id"`
+	Content   string    `json:"content"`
+	Vector    []float32 `json:"vector"`
+	TTLDays   int       `json:"ttl_days,omitempty"`
+}
+
+type kagentSearchRequest struct {
+	AgentName string    `json:"agent_name"`
+	UserID    string    `json:"user_id"`
+	Vector    []float32 `json:"vector"`
+	Limit     int       `json:"limit"`
+	MinScore  float64   `json:"min_score"`
+}
+
+type kagentSearchResult struct {
+	ID      string  `json:"id"`
+	Content string  `json:"content"`
+	Score   float64 `json:"score"`
+}
+
+// Retrieve searches the kagent memory store for the top-N most relevant chunks
+// for the given query. The contextID is not forwarded to kagent (which uses
+// agentName+userID as its own scoping keys).
+func (c *KagentClient) Retrieve(ctx context.Context, _ string, query string, topN int) ([]Chunk, error) {
+	vector, err := c.embedder.embed(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("embed query: %w", err)
+	}
+
+	body, err := json.Marshal(kagentSearchRequest{
+		AgentName: c.agentName,
+		UserID:    c.userID,
+		Vector:    vector,
+		Limit:     topN,
+		MinScore:  0.3,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal search request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpoint+"/api/memories/search", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("build search request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-User-ID", "klaus")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("search request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("memory search returned HTTP %d", resp.StatusCode)
+	}
+
+	var items []kagentSearchResult
+	if err := json.NewDecoder(resp.Body).Decode(&items); err != nil {
+		return nil, fmt.Errorf("decode search response: %w", err)
+	}
+
+	chunks := make([]Chunk, 0, len(items))
+	for _, item := range items {
+		chunks = append(chunks, Chunk{Content: item.Content, Score: float32(item.Score)})
+	}
+	return chunks, nil
+}
+
+// Store persists content to the kagent memory store asynchronously.
+// The role parameter is prepended to content to preserve speaker attribution.
+func (c *KagentClient) Store(ctx context.Context, _ string, role string, content string) error {
+	text := role + ": " + content
+	vector, err := c.embedder.embed(ctx, text)
+	if err != nil {
+		return fmt.Errorf("embed content: %w", err)
+	}
+
+	body, err := json.Marshal(kagentAddRequest{
+		AgentName: c.agentName,
+		UserID:    c.userID,
+		Content:   text,
+		Vector:    vector,
+	})
+	if err != nil {
+		return fmt.Errorf("marshal store request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpoint+"/api/memories/sessions", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("build store request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-User-ID", "klaus")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("store request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("memory store returned HTTP %d", resp.StatusCode)
+	}
+	return nil
+}

--- a/pkg/memory/kagent.go
+++ b/pkg/memory/kagent.go
@@ -97,7 +97,7 @@ func (c *KagentClient) Retrieve(ctx context.Context, _ string, query string, top
 		return nil, fmt.Errorf("build search request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-User-ID", "klaus")
+	req.Header.Set("X-User-ID", c.userID)
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
@@ -145,7 +145,7 @@ func (c *KagentClient) Store(ctx context.Context, _ string, role string, content
 		return fmt.Errorf("build store request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-User-ID", "klaus")
+	req.Header.Set("X-User-ID", c.userID)
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {

--- a/pkg/server/a2aroutes.go
+++ b/pkg/server/a2aroutes.go
@@ -9,15 +9,17 @@ import (
 )
 
 // registerA2ARoutes mounts the A2A JSONRPC endpoint and agent-card discovery
-// URLs on mux. executor may be nil; when nil, this is a no-op.
+// URLs on mux. executor may be nil; when nil, this is a no-op. Returns the
+// protected JSON-RPC handler so callers can wire it into the root path handler
+// (kagent constructs agent URLs as http://{name}.{ns}:8080 with no path).
 //
 // Routes:
-//   - /a2a and /a2a/   — A2A JSON-RPC handler (wrapped by protectedMW)
+//   - /a2a and /a2a/    — A2A JSON-RPC handler (for clients that include the path)
 //   - /.well-known/agent.json       — public agent card (unauthenticated)
 //   - /.well-known/agent-card.json  — alias for the above
-func registerA2ARoutes(mux *http.ServeMux, executor *a2apkg.Executor, protectedMW func(http.Handler) http.Handler) {
+func registerA2ARoutes(mux *http.ServeMux, executor *a2apkg.Executor, protectedMW func(http.Handler) http.Handler) http.Handler {
 	if executor == nil {
-		return
+		return nil
 	}
 
 	card := a2apkg.AgentCard()
@@ -29,4 +31,5 @@ func registerA2ARoutes(mux *http.ServeMux, executor *a2apkg.Executor, protectedM
 	jsonRPCHandler := a2asrv.NewJSONRPCHandler(requestHandler)
 	mux.Handle("/a2a", protectedMW(jsonRPCHandler))
 	mux.Handle("/a2a/", protectedMW(jsonRPCHandler))
+	return protectedMW(jsonRPCHandler)
 }

--- a/pkg/server/a2aroutes.go
+++ b/pkg/server/a2aroutes.go
@@ -2,10 +2,12 @@ package server
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/a2aproject/a2a-go/a2asrv"
 
 	a2apkg "github.com/giantswarm/klaus/pkg/a2a"
+	"github.com/giantswarm/klaus/pkg/kagentapi"
 )
 
 // registerA2ARoutes mounts the A2A JSONRPC endpoint and agent-card discovery
@@ -29,7 +31,30 @@ func registerA2ARoutes(mux *http.ServeMux, executor *a2apkg.Executor, protectedM
 
 	requestHandler := a2asrv.NewHandler(executor)
 	jsonRPCHandler := a2asrv.NewJSONRPCHandler(requestHandler)
-	mux.Handle("/a2a", protectedMW(jsonRPCHandler))
-	mux.Handle("/a2a/", protectedMW(jsonRPCHandler))
-	return protectedMW(jsonRPCHandler)
+	// extractCallerAuth sits inside protectedMW so the Authorization header
+	// is still present when we read it (the owner middleware does not strip it).
+	protected := protectedMW(extractCallerAuth(jsonRPCHandler))
+	mux.Handle("/a2a", protected)
+	mux.Handle("/a2a/", protected)
+	return protected
+}
+
+// extractCallerAuth reads the OAuth2-proxy-set Authorization header from
+// incoming A2A requests, parses the JWT sub without verification, and stores
+// the token + sub in the request context. The kagent controller (trusted-proxy
+// mode) requires both when pushing session events; this middleware makes those
+// values available to PushEvent via context.
+func extractCallerAuth(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if token, ok := strings.CutPrefix(r.Header.Get("Authorization"), "Bearer "); ok && token != "" {
+			if sub := kagentapi.ParseJWTSub(token); sub != "" {
+				ctx := kagentapi.WithAuthInfo(r.Context(), kagentapi.AuthInfo{
+					BearerToken: token,
+					UserSub:     sub,
+				})
+				r = r.WithContext(ctx)
+			}
+		}
+		next.ServeHTTP(w, r)
+	})
 }

--- a/pkg/server/a2aroutes_test.go
+++ b/pkg/server/a2aroutes_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/giantswarm/klaus/pkg/a2a"
 	"github.com/giantswarm/klaus/pkg/claude"
+	"github.com/giantswarm/klaus/pkg/memory"
 	"github.com/giantswarm/klaus/pkg/session"
 )
 
@@ -22,6 +23,7 @@ func newTestExecutor() *a2a.Executor {
 		session.NewMemoryStore(),
 		a2a.ModeChat,
 		nil,
+		memory.NoOp{},
 	)
 }
 

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -91,11 +91,24 @@ func handleBusy(process claudepkg.Prompter) http.HandlerFunc {
 	}
 }
 
-func registerOperationalRoutes(mux *http.ServeMux, process claudepkg.Prompter, mode string, ownerSubject string) {
+func registerOperationalRoutes(mux *http.ServeMux, process claudepkg.Prompter, mode string, ownerSubject string, a2aHandler http.Handler) {
 	mux.HandleFunc("/healthz", handleHealthz)
 	mux.HandleFunc("/healthz/busy", handleBusy(process))
 	mux.HandleFunc("/readyz", handleReadyz(process))
 	mux.HandleFunc("/status", handleStatus(process, mode, ownerSubject))
 	mux.Handle("/metrics", promhttp.Handler())
-	mux.HandleFunc("/", handleRoot)
+	mux.Handle("/", rootHandler(a2aHandler))
+}
+
+// rootHandler returns a catch-all handler that dispatches POST requests to
+// a2aHandler when set. kagent constructs agent URLs as http://{name}.{ns}:8080
+// with no path, so POST / must reach the A2A JSON-RPC handler.
+func rootHandler(a2aHandler http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if a2aHandler != nil && r.Method == http.MethodPost {
+			a2aHandler.ServeHTTP(w, r)
+			return
+		}
+		handleRoot(w, r)
+	})
 }

--- a/pkg/server/handlers_test.go
+++ b/pkg/server/handlers_test.go
@@ -270,7 +270,7 @@ func TestRegisterOperationalRoutes(t *testing.T) {
 	process := claude.NewProcess(claude.DefaultOptions())
 	mux := http.NewServeMux()
 
-	registerOperationalRoutes(mux, process, ModeAgent, "")
+	registerOperationalRoutes(mux, process, ModeAgent, "", nil)
 
 	paths := []string{"/healthz", "/readyz", "/status", "/", "/metrics", "/healthz/busy"}
 	for _, path := range paths {
@@ -289,7 +289,7 @@ func TestHandleMetrics(t *testing.T) {
 	process := claude.NewProcess(claude.DefaultOptions())
 	mux := http.NewServeMux()
 
-	registerOperationalRoutes(mux, process, ModeAgent, "")
+	registerOperationalRoutes(mux, process, ModeAgent, "", nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
 	w := httptest.NewRecorder()
@@ -312,7 +312,7 @@ func TestRegisterOperationalRoutes_UnknownPath(t *testing.T) {
 	process := claude.NewProcess(claude.DefaultOptions())
 	mux := http.NewServeMux()
 
-	registerOperationalRoutes(mux, process, ModeAgent, "")
+	registerOperationalRoutes(mux, process, ModeAgent, "", nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/nonexistent", nil)
 	w := httptest.NewRecorder()

--- a/pkg/server/oauth.go
+++ b/pkg/server/oauth.go
@@ -255,10 +255,10 @@ func (s *OAuthServer) Start(addr string, mode string, config OAuthConfig) error 
 	a2aMW := func(h http.Handler) http.Handler {
 		return ownerMW(s.oauthHandler.ValidateToken(h))
 	}
-	registerA2ARoutes(mux, s.executor, a2aMW)
+	a2aHandler := registerA2ARoutes(mux, s.executor, a2aMW)
 
 	// Health and status endpoints (unprotected, bypass owner validation).
-	registerOperationalRoutes(mux, s.process, mode, s.ownerSubject)
+	registerOperationalRoutes(mux, s.process, mode, s.ownerSubject, a2aHandler)
 
 	s.httpServer = &http.Server{
 		Addr:              addr,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -61,10 +61,10 @@ func NewServer(serverCtx context.Context, process claudepkg.Prompter, cfg Config
 	mux.Handle("/v1/chat/completions", ownerMW(handleChatCompletions(process)))
 
 	// A2A endpoint and agent-card discovery (optional).
-	registerA2ARoutes(mux, cfg.Executor, func(h http.Handler) http.Handler { return ownerMW(h) })
+	a2aHandler := registerA2ARoutes(mux, cfg.Executor, func(h http.Handler) http.Handler { return ownerMW(h) })
 
 	// Operational endpoints (bypass owner validation).
-	registerOperationalRoutes(mux, process, cfg.Mode, cfg.OwnerSubject)
+	registerOperationalRoutes(mux, process, cfg.Mode, cfg.OwnerSubject, a2aHandler)
 
 	s.httpServer = &http.Server{
 		Addr:              ":" + cfg.Port,

--- a/pkg/session/factory.go
+++ b/pkg/session/factory.go
@@ -2,59 +2,39 @@ package session
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 )
 
 const (
-	// BackendLocal is the default file-backed store under KLAUS_SESSION_DIR.
-	BackendLocal = "local"
-	// BackendPostgres selects the Postgres store; requires KLAUS_PG_DSN.
-	BackendPostgres = "postgres"
 	// BackendMemory is the in-memory store (tests only).
 	BackendMemory = "memory"
 
-	envBackend    = "KLAUS_RESULT_BACKEND"
 	envDSN        = "KLAUS_PG_DSN"
 	envSessionDir = "KLAUS_SESSION_DIR"
 )
 
 // NewStore constructs a Store from environment variables.
 //
-//   - Klaus_RESULT_BACKEND (default "local"): "local" | "postgres" | "memory"
-//   - KLAUS_PG_DSN: required when backend=postgres
-//   - KLAUS_SESSION_DIR: base directory for the local backend (default ~/.klaus/sessions)
+//   - KLAUS_PG_DSN: when set, use the Postgres backend. Fails fast if the DB
+//     is unreachable.
+//   - KLAUS_SESSION_DIR: base directory for the local backend (default
+//     ~/.klaus/sessions). Ignored when KLAUS_PG_DSN is set.
 //
-// The Postgres backend fails fast if no DSN is set or the DB is unreachable.
-// The local backend falls back gracefully to os.TempDir if the directory cannot
-// be created.
+// When neither variable is set, the local file backend is used and falls back
+// to os.TempDir if the directory cannot be created.
 func NewStore(ctx context.Context) (Store, error) {
-	backend := os.Getenv(envBackend)
-	if backend == "" {
-		backend = BackendLocal
-	}
-
-	switch backend {
-	case BackendPostgres:
-		dsn := os.Getenv(envDSN)
-		if dsn == "" {
-			return nil, fmt.Errorf("KLAUS_RESULT_BACKEND=postgres but KLAUS_PG_DSN is not set")
-		}
+	if dsn := os.Getenv(envDSN); dsn != "" {
 		return NewPostgresStore(ctx, dsn)
-
-	case BackendMemory:
-		return NewMemoryStore(), nil
-
-	default: // local
-		dir := os.Getenv(envSessionDir)
-		if dir == "" {
-			home, err := os.UserHomeDir()
-			if err != nil {
-				home = os.TempDir()
-			}
-			dir = filepath.Join(home, ".klaus", "sessions")
-		}
-		return NewLocalStore(dir)
 	}
+
+	dir := os.Getenv(envSessionDir)
+	if dir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			home = os.TempDir()
+		}
+		dir = filepath.Join(home, ".klaus", "sessions")
+	}
+	return NewLocalStore(dir)
 }

--- a/pkg/session/factory.go
+++ b/pkg/session/factory.go
@@ -10,16 +10,16 @@ const (
 	// BackendMemory is the in-memory store (tests only).
 	BackendMemory = "memory"
 
-	envDSN        = "KLAUS_PG_DSN"
+	envDSN        = "KLAUS_PGSQL_DSN"
 	envSessionDir = "KLAUS_SESSION_DIR"
 )
 
 // NewStore constructs a Store from environment variables.
 //
-//   - KLAUS_PG_DSN: when set, use the Postgres backend. Fails fast if the DB
+//   - KLAUS_PGSQL_DSN: when set, use the Postgres backend. Fails fast if the DB
 //     is unreachable.
 //   - KLAUS_SESSION_DIR: base directory for the local backend (default
-//     ~/.klaus/sessions). Ignored when KLAUS_PG_DSN is set.
+//     ~/.klaus/sessions). Ignored when KLAUS_PGSQL_DSN is set.
 //
 // When neither variable is set, the local file backend is used and falls back
 // to os.TempDir if the directory cannot be created.

--- a/pkg/session/local.go
+++ b/pkg/session/local.go
@@ -20,8 +20,7 @@ type localSession struct {
 // under a configurable directory. It is the default backend when no Postgres DSN
 // is provided, mirroring the existing KLAUS_RESULT_DIR pattern.
 //
-// Writes are serialized per-context via a per-file mutex, so concurrent turns on
-// different contexts proceed in parallel.
+// All file operations are serialized via a single mutex.
 type LocalStore struct {
 	dir string
 	mu  sync.Mutex // guards file-level operations
@@ -79,6 +78,9 @@ func (l *LocalStore) SessionID(_ context.Context, contextID string) (string, err
 }
 
 func (l *LocalStore) BindSession(_ context.Context, contextID, sessionID string) error {
+	if sessionID == "" {
+		return nil
+	}
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	s, err := l.load(contextID)

--- a/pkg/session/memory_store.go
+++ b/pkg/session/memory_store.go
@@ -28,6 +28,9 @@ func (m *MemoryStore) SessionID(_ context.Context, contextID string) (string, er
 }
 
 func (m *MemoryStore) BindSession(_ context.Context, contextID, sessionID string) error {
+	if sessionID == "" {
+		return nil
+	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.sessions[contextID] = sessionID

--- a/pkg/session/postgres.go
+++ b/pkg/session/postgres.go
@@ -63,6 +63,9 @@ func (p *PostgresStore) SessionID(ctx context.Context, contextID string) (string
 }
 
 func (p *PostgresStore) BindSession(ctx context.Context, contextID, sessionID string) error {
+	if sessionID == "" {
+		return nil
+	}
 	_, err := p.db.ExecContext(ctx, `
 		INSERT INTO sessions.bindings (context_id, session_id, updated_at)
 		VALUES ($1, $2, now())

--- a/pkg/session/store.go
+++ b/pkg/session/store.go
@@ -9,7 +9,7 @@
 //   - Conversation history is queryable by the MCP messages tool and the kagent UI.
 //
 // Note: cross-restart resume requires both a persistent Store backend (Postgres
-// via KLAUS_PG_DSN) AND that the claude CLI session files (~/.claude/) survive
+// via KLAUS_PGSQL_DSN) AND that the claude CLI session files (~/.claude/) survive
 // the restart (i.e. mounted on a PVC). A surviving store binding alone is not
 // sufficient — the CLI cannot resume a session whose files no longer exist.
 //

--- a/pkg/session/store.go
+++ b/pkg/session/store.go
@@ -5,8 +5,13 @@
 // the warm-pool substrate. The Store tracks the contextID → sessionID binding and
 // persists the full conversation history (one Turn per model exchange) so that:
 //
-//   - Resume across pod restarts is driven by the stored sessionID.
+//   - The stored sessionID can be threaded to --resume on subsequent turns.
 //   - Conversation history is queryable by the MCP messages tool and the kagent UI.
+//
+// Note: cross-restart resume requires both a persistent Store backend (Postgres
+// via KLAUS_PG_DSN) AND that the claude CLI session files (~/.claude/) survive
+// the restart (i.e. mounted on a PVC). A surviving store binding alone is not
+// sufficient — the CLI cannot resume a session whose files no longer exist.
 //
 // Use NewStore to obtain a backend-selected implementation.
 package session

--- a/pkg/session/store_test.go
+++ b/pkg/session/store_test.go
@@ -102,11 +102,11 @@ func TestLocalStore_AutoSeq(t *testing.T) {
 }
 
 // TestPostgresStore runs the store contract against a real Postgres instance.
-// It is skipped unless KLAUS_PG_DSN is set.
+// It is skipped unless KLAUS_PGSQL_DSN is set.
 func TestPostgresStore(t *testing.T) {
-	dsn := os.Getenv("KLAUS_PG_DSN")
+	dsn := os.Getenv("KLAUS_PGSQL_DSN")
 	if dsn == "" {
-		t.Skip("KLAUS_PG_DSN not set, skipping Postgres store test")
+		t.Skip("KLAUS_PGSQL_DSN not set, skipping Postgres store test")
 	}
 
 	store, err := session.NewPostgresStore(t.Context(), dsn)


### PR DESCRIPTION
## What

Implements `pkg/memory.Client` backed by the kagent memory API:

- `KagentClient.Retrieve`: embeds the query via an OpenAI-compatible endpoint, searches the kagent pgvector store (`POST /api/memories/search`), returns the top-N chunks by cosine similarity
- `KagentClient.Store`: embeds content and stores it in the kagent memory store (`POST /api/memories/sessions`)
- Per-user memory scoping via `memory.WithUserID(ctx, sub)`: OIDC subject set in context takes precedence over the static `KAGENT_MEMORY_USER_ID` fallback
- Embedding configured via `KKAUS_EMBEDDING_MODEL` and `KKAUS_EMBEDDING_ENDPOINT` (defaults to OpenAI v1)
- Backend enabled by setting `KAGENT_MEMORY_ENDPOINT`; falls back to `memory.NoOp` when unset

The executor calls `Retrieve` before each turn to prepend relevant memory chunks to the system prompt, and `Store` after each turn in a background goroutine.