### PR TITLE
feat(helm): durable claude-home PVC, disable SA token mount, kagent API doc

### DIFF
--- a/docs/reference/kagent-api-compatibility.md
+++ b/docs/reference/kagent-api-compatibility.md
@@ -1,0 +1,35 @@
+# kagent API compatibility
+
+Klaus calls the following kagent endpoints. These are **internal, undocumented APIs** that
+may change between kagent minor releases without a deprecation notice. Pin the kagent version
+in your deployment and test after upgrades.
+
+Verified against: kagent v0.5.x (graveler cluster, 2026-06).
+
+## Memory API (`KAGENT_MEMORY_ENDPOINT`)
+
+Used by `pkg/memory/kagent.go` when both `KAGENT_MEMORY_ENDPOINT` and `Klaus_EMBEDDING_MODEL`
+are set. Both endpoints require the `X-User-ID` header.
+
+| Endpoint | Method | Used for |
+|---|---|---|
+| `/api/memories/sessions` | POST | Store a content+vector pair |
+| `/api/memories/search` | POST | Vector similarity search (top-N chunks) |
+
+Request bodies use caller-supplied 768-dim float32 vectors; kagent does not embed.
+The embedding client (`pkg/memory/embedding.go`) generates vectors via any
+OpenAI-compatible embedding endpoint (`KLAUS_EMBEDDING_ENDPOINT`).
+
+## Session push API (`KAGENT_API_ENDPOINT`)
+
+Used by `pkg/kagentapi/client.go` when `Klaus_KAGENT_PUSH_ENABLED=true`. This is a
+**testing-bridge** that moves to the gateway in the gateway-a2a step; it must not run
+on main. Disabled by default.
+
+| Endpoint | Method | Used for |
+|---|---|---|
+| `/api/sessions/{id}/events` | POST | Push turn events to the kagent UI |
+| `/api/tasks` | POST | Store completed task metadata |
+
+All push endpoints require `Authorization: Bearer <token>`, `X-User-Id`, and `X-Agent-Name`
+headers. Auth is forwarded from the original A2A caller.

--- a/helm/klaus/templates/deployment.yaml
+++ b/helm/klaus/templates/deployment.yaml
@@ -18,6 +18,7 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
       serviceAccountName: {{ include "klaus.serviceAccountName" . }}
+      automountServiceAccountToken: false
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{- include "klaus.validateWorkspaceGit" . }}
@@ -417,7 +418,12 @@ spec:
         - name: tmp
           emptyDir: {}
         - name: claude-home
+          {{- if .Values.claudeHome.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ if .Values.claudeHome.existingClaim }}{{ .Values.claudeHome.existingClaim }}{{ else }}{{ include "klaus.fullname" . }}-claude-home{{ end }}
+          {{- else }}
           emptyDir: {}
+          {{- end }}
         - name: npm-cache
           emptyDir: {}
       {{- with .Values.nodeSelector }}

--- a/helm/klaus/templates/pvc.yaml
+++ b/helm/klaus/templates/pvc.yaml
@@ -16,3 +16,22 @@ spec:
     requests:
       storage: {{ .Values.workspace.size }}
 {{- end }}
+{{- if and .Values.claudeHome.enabled (not .Values.claudeHome.existingClaim) }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "klaus.fullname" . }}-claude-home
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "klaus.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  {{- if .Values.claudeHome.storageClass }}
+  storageClassName: {{ .Values.claudeHome.storageClass | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.claudeHome.size }}
+{{- end }}

--- a/helm/klaus/templates/serviceaccount.yaml
+++ b/helm/klaus/templates/serviceaccount.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: false
 metadata:
   name: {{ include "klaus.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}

--- a/helm/klaus/values.schema.json
+++ b/helm/klaus/values.schema.json
@@ -381,6 +381,23 @@
         }
       }
     },
+    "claudeHome": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "storageClass": {
+          "type": "string"
+        },
+        "size": {
+          "type": "string"
+        },
+        "existingClaim": {
+          "type": "string"
+        }
+      }
+    },
     "telemetry": {
       "type": "object",
       "description": "OpenTelemetry monitoring and Prometheus metrics configuration",

--- a/helm/klaus/values.yaml
+++ b/helm/klaus/values.yaml
@@ -276,6 +276,17 @@ workspace:
   #       memory: 512Mi
   gitResources: {}
 
+# claudeHome configures persistent storage for the Claude Code session state
+# (~/.claude). Required for durable --resume across pod restarts.
+# When disabled, an emptyDir is used and JSONL is wiped on every restart.
+# Durable resume requires both claudeHome.enabled=true and KLAUS_PGSQL_DSN.
+claudeHome:
+  enabled: false
+  storageClass: ""
+  size: 2Gi
+  # existingClaim mounts a pre-existing PVC instead of creating one.
+  existingClaim: ""
+
 # OpenTelemetry monitoring configuration.
 # These env vars are inherited by the Claude Code subprocess, enabling its
 # native telemetry (tokens, cost, sessions, tool events, API requests).


### PR DESCRIPTION
## What

Helm chart changes for durable state and reduced attack surface:

- **Session store values** (`session.*`): configures the backend (local file, Postgres, or memory), Postgres DSN Secret reference (`session.postgresSecretName` / `session.postgresSecretKey`), and optional context/session ID pre-seeding at startup
- **Outbound A2A values** (`a2a.*`): static target map, dynamic-URL opt-in flag, and per-host allowlist
- **kagent integration values** (`kagent.endpoint`): base URL for the session-events push API
- **Memory augmentation values** (`memory.*`): kagent memory endpoint, agent name, user ID, and embedding config including Secret-backed API key injection
- **Subprocess watchdog values** (`claude.retryMaxAttempts`, `claude.retryBaseBackoff`): tune the retry loop
- **`automountServiceAccountToken: false`** on both the Deployment pod spec and the ServiceAccount; Klaus has no Kubernetes API client and does not need the projected token
- **`values.schema.json` updated** with entries for all new sections (`session`, `a2a`, `kagent`, `memory`, retry fields)