### PR TITLE
feat(a2a): emit generic token_usage on final artifact

### DIFF
--- a/pkg/a2a/events.go
+++ b/pkg/a2a/events.go
@@ -26,9 +26,7 @@ func workingEvent(execCtx *a2asrv.ExecutorContext, msg string) *a2a.TaskStatusUp
 }
 
 // artifactEvent returns a TaskArtifactUpdateEvent with LastChunk=true carrying
-// the full response text. sessionID and usage are attached as metadata when non-empty/nil.
-// usage is stored under the generic "token_usage" key so callers can translate it to
-// whatever downstream format they need without embedding that knowledge here.
+// the full response text. sessionID and usage are attached as metadata when non-nil/non-empty.
 func artifactEvent(execCtx *a2asrv.ExecutorContext, text, sessionID string, usage *claude.TokenUsage) *a2a.TaskArtifactUpdateEvent {
 	ev := a2a.NewArtifactEvent(execCtx, a2a.NewTextPart(text))
 	ev.LastChunk = true

--- a/pkg/a2a/events.go
+++ b/pkg/a2a/events.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/a2aproject/a2a-go/v2/a2a"
 	"github.com/a2aproject/a2a-go/v2/a2asrv"
+
+	"github.com/giantswarm/klaus/pkg/claude"
 )
 
 // workingEvent returns a TaskStateWorking status update with an optional
@@ -24,15 +26,27 @@ func workingEvent(execCtx *a2asrv.ExecutorContext, msg string) *a2a.TaskStatusUp
 }
 
 // artifactEvent returns a TaskArtifactUpdateEvent with LastChunk=true carrying
-// the full response text. sessionID is attached as metadata when non-empty.
-func artifactEvent(execCtx *a2asrv.ExecutorContext, text, sessionID string) *a2a.TaskArtifactUpdateEvent {
+// the full response text. sessionID and usage are attached as metadata when non-empty/nil.
+// usage is stored under the generic "token_usage" key so callers can translate it to
+// whatever downstream format they need without embedding that knowledge here.
+func artifactEvent(execCtx *a2asrv.ExecutorContext, text, sessionID string, usage *claude.TokenUsage) *a2a.TaskArtifactUpdateEvent {
 	ev := a2a.NewArtifactEvent(execCtx, a2a.NewTextPart(text))
 	ev.LastChunk = true
-	if sessionID != "" {
+	if sessionID != "" || usage != nil {
 		if ev.Artifact.Metadata == nil {
 			ev.Artifact.Metadata = map[string]any{}
 		}
-		ev.Artifact.Metadata["session_id"] = sessionID
+		if sessionID != "" {
+			ev.Artifact.Metadata["session_id"] = sessionID
+		}
+		if usage != nil {
+			ev.Artifact.Metadata["token_usage"] = map[string]any{
+				"input_tokens":               usage.InputTokens,
+				"output_tokens":              usage.OutputTokens,
+				"cache_creation_input_tokens": usage.CacheCreationInputTokens,
+				"cache_read_input_tokens":    usage.CacheReadInputTokens,
+			}
+		}
 	}
 	return ev
 }

--- a/pkg/a2a/events.go
+++ b/pkg/a2a/events.go
@@ -41,10 +41,10 @@ func artifactEvent(execCtx *a2asrv.ExecutorContext, text, sessionID string, usag
 		}
 		if usage != nil {
 			ev.Artifact.Metadata["token_usage"] = map[string]any{
-				"input_tokens":               usage.InputTokens,
-				"output_tokens":              usage.OutputTokens,
+				"input_tokens":                usage.InputTokens,
+				"output_tokens":               usage.OutputTokens,
 				"cache_creation_input_tokens": usage.CacheCreationInputTokens,
-				"cache_read_input_tokens":    usage.CacheReadInputTokens,
+				"cache_read_input_tokens":     usage.CacheReadInputTokens,
 			}
 		}
 	}

--- a/pkg/a2a/executor.go
+++ b/pkg/a2a/executor.go
@@ -92,7 +92,7 @@ func (e *Executor) Execute(ctx context.Context, execCtx *a2asrv.ExecutorContext)
 			reply := fmt.Sprintf(
 				"`%s` is not available in this environment — Claude Code is running headless. "+
 					"Model and configuration are controlled via environment variables (CLAUDE_MODEL, etc.).", cmd)
-			if !yield(artifactEvent(execCtx, reply, ""), nil) {
+			if !yield(artifactEvent(execCtx, reply, "", nil), nil) {
 				return
 			}
 			yield(completedEvent(execCtx), nil)
@@ -238,7 +238,8 @@ func (e *Executor) Execute(ctx context.Context, execCtx *a2asrv.ExecutorContext)
 		}
 
 		if result != "" {
-			if !yield(artifactEvent(execCtx, result, streamSessionID), nil) {
+			usage := claude.CollectTokenUsage(messages)
+			if !yield(artifactEvent(execCtx, result, streamSessionID, usage), nil) {
 				return
 			}
 		}

--- a/pkg/a2a/executor_test.go
+++ b/pkg/a2a/executor_test.go
@@ -450,6 +450,59 @@ func (p *staleResumePrompter) Status() claude.StatusInfo {
 	return claude.StatusInfo{Status: claude.ProcessStatusIdle}
 }
 
+// TestExecutor_ArtifactTokenUsage verifies that token_usage is attached to the
+// final artifact when the prompter emits assistant messages with usage data, and
+// absent for synthetic responses (slash commands) where no usage is present.
+func TestExecutor_ArtifactTokenUsage(t *testing.T) {
+	t.Run("token_usage present when prompter emits usage", func(t *testing.T) {
+		fp := &fakePrompter{
+			messages: []claude.StreamMessage{
+				{Type: claude.MessageTypeSystem, SessionID: "sess-1"},
+				{
+					Type:    claude.MessageTypeAssistant,
+					Subtype: claude.SubtypeText,
+					Text:    "answer",
+					Usage:   &claude.TokenUsage{InputTokens: 100, OutputTokens: 50},
+				},
+				{Type: claude.MessageTypeResult, Result: "answer"},
+			},
+		}
+		exec := a2a.New(fp, a2a.ModeAgent)
+		events, err := collectEvents(t.Context(), exec.Execute(t.Context(), makeExecCtx("ctx-usage", "what is 2+2?")))
+		require.NoError(t, err)
+
+		var artifact *a2asdk.TaskArtifactUpdateEvent
+		for _, ev := range events {
+			if a, ok := ev.(*a2asdk.TaskArtifactUpdateEvent); ok {
+				artifact = a
+			}
+		}
+		require.NotNil(t, artifact, "expected an artifact event")
+		require.NotNil(t, artifact.Artifact.Metadata, "artifact must carry metadata")
+
+		usage, ok := artifact.Artifact.Metadata["token_usage"].(map[string]any)
+		require.True(t, ok, "token_usage must be a map[string]any")
+		assert.EqualValues(t, int64(100), usage["input_tokens"])
+		assert.EqualValues(t, int64(50), usage["output_tokens"])
+	})
+
+	t.Run("token_usage absent for slash-command response", func(t *testing.T) {
+		fp := &fakePrompter{}
+		exec := a2a.New(fp, a2a.ModeAgent)
+		events, err := collectEvents(t.Context(), exec.Execute(t.Context(), makeExecCtx("ctx-slash", "/clear")))
+		require.NoError(t, err)
+
+		for _, ev := range events {
+			if a, ok := ev.(*a2asdk.TaskArtifactUpdateEvent); ok {
+				if a.Artifact != nil && a.Artifact.Metadata != nil {
+					_, hasUsage := a.Artifact.Metadata["token_usage"]
+					assert.False(t, hasUsage, "slash-command artifact must not carry token_usage")
+				}
+			}
+		}
+	})
+}
+
 // TestExecutor_StaleResumeRetry verifies that when --resume fails (session file
 // gone after pod restart), the executor retries with a fresh session and the
 // turn completes rather than failing.

--- a/pkg/claude/message.go
+++ b/pkg/claude/message.go
@@ -741,6 +741,26 @@ func Truncate(s string, maxLen int) string {
 	return string(runes[:maxLen]) + "..."
 }
 
+// CollectTokenUsage sums token counts across all assistant messages in the stream.
+// Returns nil when no usage is present (e.g. synthetic slash-command responses).
+func CollectTokenUsage(messages []StreamMessage) *TokenUsage {
+	var total TokenUsage
+	found := false
+	for _, msg := range messages {
+		if msg.Usage != nil {
+			total.InputTokens += msg.Usage.InputTokens
+			total.OutputTokens += msg.Usage.OutputTokens
+			total.CacheCreationInputTokens += msg.Usage.CacheCreationInputTokens
+			total.CacheReadInputTokens += msg.Usage.CacheReadInputTokens
+			found = true
+		}
+	}
+	if !found {
+		return nil
+	}
+	return &total
+}
+
 // CollectResultText extracts the result text from a completed set of stream messages.
 // It returns the text from the last result message, falling back to concatenated
 // assistant text messages if no result message contains text.

--- a/pkg/claude/message_test.go
+++ b/pkg/claude/message_test.go
@@ -998,3 +998,46 @@ func TestParseStreamMessage_StreamEvent_InputJSONDelta(t *testing.T) {
 		t.Errorf("expected InputJSONDelta %q, got %q", `{"cmd":"ls"}`, msg.InputJSONDelta)
 	}
 }
+
+func TestCollectTokenUsage(t *testing.T) {
+	t.Run("sums across assistant messages", func(t *testing.T) {
+		messages := []StreamMessage{
+			{Type: MessageTypeSystem, SessionID: "s1"},
+			{Type: MessageTypeAssistant, Subtype: SubtypeText, Text: "hello", Usage: &TokenUsage{InputTokens: 10, OutputTokens: 20}},
+			{Type: MessageTypeAssistant, Subtype: SubtypeToolUse, Usage: &TokenUsage{InputTokens: 5, OutputTokens: 3, CacheReadInputTokens: 7}},
+			{Type: MessageTypeResult, Result: "done"},
+		}
+		got := CollectTokenUsage(messages)
+		if got == nil {
+			t.Fatal("expected non-nil usage")
+		}
+		if got.InputTokens != 15 {
+			t.Errorf("InputTokens: want 15, got %d", got.InputTokens)
+		}
+		if got.OutputTokens != 23 {
+			t.Errorf("OutputTokens: want 23, got %d", got.OutputTokens)
+		}
+		if got.CacheReadInputTokens != 7 {
+			t.Errorf("CacheReadInputTokens: want 7, got %d", got.CacheReadInputTokens)
+		}
+		if got.CacheCreationInputTokens != 0 {
+			t.Errorf("CacheCreationInputTokens: want 0, got %d", got.CacheCreationInputTokens)
+		}
+	})
+
+	t.Run("nil when no usage present", func(t *testing.T) {
+		messages := []StreamMessage{
+			{Type: MessageTypeSystem, SessionID: "s1"},
+			{Type: MessageTypeResult, Result: "done"},
+		}
+		if got := CollectTokenUsage(messages); got != nil {
+			t.Errorf("expected nil, got %+v", got)
+		}
+	})
+
+	t.Run("nil for empty slice", func(t *testing.T) {
+		if got := CollectTokenUsage(nil); got != nil {
+			t.Errorf("expected nil, got %+v", got)
+		}
+	})
+}


### PR DESCRIPTION
## Why

Stacks on #303. The gateway translates Klaus turn data into kagent's session history format. Token counts are part of that data — kagent's UI renders them per-message — but Klaus had no way to surface them across the A2A boundary.

The translation belongs in the gateway, not in Klaus. Klaus should not know about kagent's camelCase metadata shape; it just emits what it knows in its own terms.

## What

Adds token count emission to the final A2A artifact using generic, Claude-native field names. The gateway reads these and translates to whatever downstream format it needs.

### `pkg/claude/message.go`

`CollectTokenUsage([]StreamMessage) *TokenUsage` sums `msg.Usage` across all stream messages in a turn. Returns nil when no usage is present (slash-command responses, tool-only turns where Claude never speaks).

### `pkg/a2a/events.go`

`artifactEvent` gains a `usage *claude.TokenUsage` parameter. When non-nil, it writes:

```json
{
  "token_usage": {
    "input_tokens": N,
    "output_tokens": N,
    "cache_creation_input_tokens": N,
    "cache_read_input_tokens": N
  }
}
```

to `Artifact.Metadata`. Snake_case, Claude SDK naming. No kagent keys here.

### `pkg/a2a/executor.go`

Calls `CollectTokenUsage(messages)` after the stream finishes and passes the result to `artifactEvent`. The slash-command path passes nil (no LLM call, no usage).

### Gateway side (gateway PR #67)

Reads `token_usage` off the last artifact and translates to `kagent_usage_metadata` (camelCase, `promptTokenCount`/`candidatesTokenCount`/`totalTokenCount`) before calling `StoreTask` and `PushEvent`. Handles the float64 vs int64 JSON round-trip since `Artifact.Metadata` is `map[string]any`.