### PR TITLE
feat(kagentapi,memory): push turn history, usage, and per-user cross-session memory

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -22,6 +22,7 @@ import (
 	a2apkg "github.com/giantswarm/klaus/pkg/a2a"
 	"github.com/giantswarm/klaus/pkg/claude"
 	"github.com/giantswarm/klaus/pkg/config"
+	"github.com/giantswarm/klaus/pkg/kagentapi"
 	"github.com/giantswarm/klaus/pkg/project"
 	"github.com/giantswarm/klaus/pkg/server"
 )
@@ -387,7 +388,7 @@ func runServe(portFlag string, cfg config.Config, enableOAuth bool, oauthConfig 
 	if cfg.Claude.Mode != server.ModeChat {
 		a2aMode = a2apkg.ModeAgent
 	}
-	executor := a2apkg.New(process, a2aMode)
+	executor := a2apkg.New(process, a2aMode, kagentapi.New(cfg.Kagent.APIEndpoint, cfg.Kagent.AgentRef))
 
 	srvCfg := server.Config{
 		Port:         listenPort,

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -23,6 +23,7 @@ import (
 	"github.com/giantswarm/klaus/pkg/claude"
 	"github.com/giantswarm/klaus/pkg/config"
 	"github.com/giantswarm/klaus/pkg/kagentapi"
+	"github.com/giantswarm/klaus/pkg/memory"
 	"github.com/giantswarm/klaus/pkg/project"
 	"github.com/giantswarm/klaus/pkg/server"
 )
@@ -388,7 +389,8 @@ func runServe(portFlag string, cfg config.Config, enableOAuth bool, oauthConfig 
 	if cfg.Claude.Mode != server.ModeChat {
 		a2aMode = a2apkg.ModeAgent
 	}
-	executor := a2apkg.New(process, a2aMode, kagentapi.New(cfg.Kagent.APIEndpoint, cfg.Kagent.AgentRef))
+	memStore := memory.New(cfg.Kagent.APIEndpoint, cfg.Kagent.AgentRef)
+	executor := a2apkg.New(process, a2aMode, kagentapi.New(cfg.Kagent.APIEndpoint, cfg.Kagent.AgentRef), memStore, cfg.Memory.TopK)
 
 	srvCfg := server.Config{
 		Port:         listenPort,

--- a/docs/reference/kagent-api-compatibility.md
+++ b/docs/reference/kagent-api-compatibility.md
@@ -1,0 +1,39 @@
+# kagent API compatibility
+
+Klaus calls the following kagent endpoints. These are **internal, undocumented APIs** that
+may change between kagent minor releases without a deprecation notice. Pin the kagent version
+in your deployment and test after upgrades.
+
+Verified against: kagent v0.5.x (graveler cluster, 2026-06).
+
+## Session push API (`KAGENT_API_ENDPOINT`)
+
+Used by `pkg/kagentapi/client.go` when `KAGENT_API_ENDPOINT` is set. The pod pushes turn
+history and token usage directly to kagent after each A2A turn.
+
+| Endpoint | Method | Used for |
+|---|---|---|
+| `/api/sessions/{contextID}/events` | POST | Push a turn event (user or agent message) |
+| `/api/tasks` | POST | Store completed task metadata with usage |
+
+All endpoints require:
+
+- `Authorization: Bearer <token>` — the in-request user JWT when available, otherwise the
+  projected SA token at `/var/run/secrets/kagent/token` (audience: `kagent`).
+- `X-User-Id` — the `sub` claim of the bearer token, or the JWT `sub` parsed from the caller's
+  token. Required by kagent to key the session to a user.
+- `X-Agent-Name` — set from `KAGENT_AGENT_REF`; identifies which Agent CR is generating events.
+
+## Memory API (`KAGENT_API_ENDPOINT`)
+
+Used by `pkg/memory/kagent.go` when `MEMORY_ENABLED=true` and an embedding endpoint is
+configured. Both endpoints require `X-User-Id`.
+
+| Endpoint | Method | Used for |
+|---|---|---|
+| `/api/memories/sessions` | POST | Store a content+vector pair |
+| `/api/memories/search` | POST | Vector similarity search (top-N chunks) |
+
+Request bodies use caller-supplied float32 vectors; kagent does not embed. The embedding
+client (`pkg/memory/embedding.go`) generates vectors via an OpenAI-compatible endpoint
+(`KLAUS_EMBEDDING_ENDPOINT`, `Klaus_EMBEDDING_MODEL`).

--- a/helm/klaus/templates/deployment.yaml
+++ b/helm/klaus/templates/deployment.yaml
@@ -349,6 +349,28 @@ spec:
             - name: KAGENT_AGENT_REF
               value: {{ .Values.kagent.agentRef | quote }}
             {{- end }}
+            # cross-session memory
+            {{- if .Values.memory.enabled }}
+            - name: MEMORY_ENABLED
+              value: "true"
+            - name: MEMORY_TOP_K
+              value: {{ .Values.memory.topK | quote }}
+            {{- if .Values.memory.embedding.endpoint }}
+            - name: KLAUS_EMBEDDING_ENDPOINT
+              value: {{ .Values.memory.embedding.endpoint | quote }}
+            {{- end }}
+            {{- if .Values.memory.embedding.model }}
+            - name: KLAUS_EMBEDDING_MODEL
+              value: {{ .Values.memory.embedding.model | quote }}
+            {{- end }}
+            {{- if .Values.memory.embedding.apiKeySecretRef.name }}
+            - name: KLAUS_EMBEDDING_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.memory.embedding.apiKeySecretRef.name | quote }}
+                  key: {{ .Values.memory.embedding.apiKeySecretRef.key | quote }}
+            {{- end }}
+            {{- end }}
           volumeMounts:
             {{- if or .Values.claude.mcpConfig (include "klaus.hasMcpServers" .) }}
             - name: config

--- a/helm/klaus/templates/deployment.yaml
+++ b/helm/klaus/templates/deployment.yaml
@@ -340,6 +340,15 @@ spec:
             - name: KLAUS_A2A_ALLOWED_HOSTS
               value: {{ .Values.a2a.allowedHosts | join "," | quote }}
             {{- end }}
+            # kagent history push
+            {{- if .Values.kagent.apiEndpoint }}
+            - name: KAGENT_API_ENDPOINT
+              value: {{ .Values.kagent.apiEndpoint | quote }}
+            {{- end }}
+            {{- if .Values.kagent.agentRef }}
+            - name: KAGENT_AGENT_REF
+              value: {{ .Values.kagent.agentRef | quote }}
+            {{- end }}
           volumeMounts:
             {{- if or .Values.claude.mcpConfig (include "klaus.hasMcpServers" .) }}
             - name: config

--- a/helm/klaus/templates/deployment.yaml
+++ b/helm/klaus/templates/deployment.yaml
@@ -344,6 +344,8 @@ spec:
             {{- if .Values.kagent.apiEndpoint }}
             - name: KAGENT_API_ENDPOINT
               value: {{ .Values.kagent.apiEndpoint | quote }}
+            - name: KAGENT_SA_TOKEN_PATH
+              value: /var/run/secrets/kagent/token
             {{- end }}
             {{- if .Values.kagent.agentRef }}
             - name: KAGENT_AGENT_REF
@@ -422,7 +424,12 @@ spec:
             - name: claude-home
               mountPath: /home/node/.claude
             - name: npm-cache
-              mountPath: /home/node/.npm
+              mountPath: /home/klaus/.npm
+            {{- if .Values.kagent.apiEndpoint }}
+            - name: kagent-sa-token
+              mountPath: /var/run/secrets/kagent
+              readOnly: true
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /healthz
@@ -493,6 +500,15 @@ spec:
           {{- end }}
         - name: npm-cache
           emptyDir: {}
+        {{- if .Values.kagent.apiEndpoint }}
+        - name: kagent-sa-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  audience: kagent
+                  expirationSeconds: 3600
+                  path: token
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/klaus/values.schema.json
+++ b/helm/klaus/values.schema.json
@@ -482,7 +482,42 @@
         }
       }
     },
-    "memory": {"type": "object"},
+    "memory": {
+      "type": "object",
+      "description": "Per-user cross-session memory via the kagent pgvector API",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable cross-session memory retrieval and recording"
+        },
+        "topK": {
+          "type": "integer",
+          "description": "Maximum number of memory chunks injected per turn",
+          "minimum": 1
+        },
+        "embedding": {
+          "type": "object",
+          "properties": {
+            "endpoint": {
+              "type": "string",
+              "description": "OpenAI-compatible embedding base URL"
+            },
+            "model": {
+              "type": "string",
+              "description": "Embedding model name (e.g. text-embedding-3-small)"
+            },
+            "apiKeySecretRef": {
+              "type": "object",
+              "description": "Secret reference for the embedding API key",
+              "properties": {
+                "name": {"type": "string"},
+                "key": {"type": "string"}
+              }
+            }
+          }
+        }
+      }
+    },
     "telemetry": {
       "type": "object",
       "description": "OpenTelemetry monitoring and Prometheus metrics configuration",

--- a/helm/klaus/values.yaml
+++ b/helm/klaus/values.yaml
@@ -328,6 +328,15 @@ a2a:
   #     - agent2.example.com:8080
   allowedHosts: []
 
+# kagent-controller history and usage push.
+# When apiEndpoint is empty, all push operations are disabled.
+kagent:
+  # apiEndpoint is the base URL of the kagent-controller REST API.
+  # Example: http://kagent-controller.kagent.svc.cluster.local:8083
+  apiEndpoint: ""
+  # agentRef is sent as the X-Agent-Name header on push requests.
+  agentRef: ""
+
 
 # OpenTelemetry monitoring configuration.
 # These env vars are inherited by the Claude Code subprocess, enabling its

--- a/helm/klaus/values.yaml
+++ b/helm/klaus/values.yaml
@@ -337,6 +337,31 @@ kagent:
   # agentRef is sent as the X-Agent-Name header on push requests.
   agentRef: ""
 
+# Per-user cross-session memory via the kagent pgvector API.
+# Uses kagent.apiEndpoint and kagent.agentRef as the backend.
+# Requires an OpenAI-compatible embedding endpoint (KLAUS_EMBEDDING_*).
+memory:
+  # enabled turns on cross-session memory retrieval and recording.
+  # Env: MEMORY_ENABLED
+  enabled: false
+  # topK is the maximum number of memory chunks to inject per turn.
+  # Env: MEMORY_TOP_K
+  topK: 5
+  embedding:
+    # endpoint is the OpenAI-compatible embedding base URL.
+    # Env: KLAUS_EMBEDDING_ENDPOINT (default: https://api.openai.com/v1)
+    endpoint: ""
+    # model is the embedding model name (e.g. text-embedding-3-small).
+    # Env: Klaus_EMBEDDING_MODEL
+    model: ""
+    # apiKey for the embedding endpoint; omit for unauthenticated vLLM endpoints.
+    # Env: KLAUS_EMBEDDING_API_KEY
+    apiKeySecretRef: {}
+    # Example:
+    #   apiKeySecretRef:
+    #     name: my-embedding-api-key
+    #     key: api-key
+
 
 # OpenTelemetry monitoring configuration.
 # These env vars are inherited by the Claude Code subprocess, enabling its

--- a/helm/klaus/values.yaml
+++ b/helm/klaus/values.yaml
@@ -352,7 +352,7 @@ memory:
     # Env: KLAUS_EMBEDDING_ENDPOINT (default: https://api.openai.com/v1)
     endpoint: ""
     # model is the embedding model name (e.g. text-embedding-3-small).
-    # Env: Klaus_EMBEDDING_MODEL
+    # Env: KLAUS_EMBEDDING_MODEL
     model: ""
     # apiKey for the embedding endpoint; omit for unauthenticated vLLM endpoints.
     # Env: KLAUS_EMBEDDING_API_KEY

--- a/pkg/a2a/executor.go
+++ b/pkg/a2a/executor.go
@@ -349,7 +349,7 @@ func (e *Executor) pushTurnAsync(ctx context.Context, execCtx *a2asrv.ExecutorCo
 	agentMeta := adkUsageMetadata(claude.CollectTokenUsage(messages))
 
 	go func() {
-		pushCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		pushCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 15*time.Second)
 		defer cancel()
 
 		e.kagent.PushEvent(pushCtx, contextID, kagentapi.NewSessionEvent(taskID+"-user", "user", userText), auth)

--- a/pkg/a2a/executor.go
+++ b/pkg/a2a/executor.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/giantswarm/klaus/pkg/claude"
 	"github.com/giantswarm/klaus/pkg/kagentapi"
+	"github.com/giantswarm/klaus/pkg/memory"
 	"github.com/giantswarm/klaus/pkg/telemetry"
 )
 
@@ -38,6 +39,8 @@ type Executor struct {
 	prompter claude.Prompter
 	mode     Mode
 	kagent   *kagentapi.Client // nil-safe; no-op when endpoint is unset
+	mem      memory.Store      // nil-safe; NoOp when memory is disabled
+	memTopK  int
 
 	mu       sync.Mutex
 	inFlight map[string]struct{}
@@ -48,11 +51,21 @@ var _ a2asrv.AgentExecutor = (*Executor)(nil)
 
 // New returns an Executor. prompter may be a *claude.Process (agent mode) or a
 // *claude.PersistentProcess (chat mode). kagentClient may be nil (no-op).
-func New(prompter claude.Prompter, mode Mode, kagentClient *kagentapi.Client) *Executor {
+// memStore may be nil (treated as NoOp). memTopK is the max chunks to retrieve
+// per turn; 0 uses the default of 5.
+func New(prompter claude.Prompter, mode Mode, kagentClient *kagentapi.Client, memStore memory.Store, memTopK int) *Executor {
+	if memStore == nil {
+		memStore = memory.NoOp{}
+	}
+	if memTopK <= 0 {
+		memTopK = 5
+	}
 	return &Executor{
 		prompter: prompter,
 		mode:     mode,
 		kagent:   kagentClient,
+		mem:      memStore,
+		memTopK:  memTopK,
 		inFlight: make(map[string]struct{}),
 		sessions: make(map[string]string),
 	}
@@ -111,6 +124,20 @@ func (e *Executor) Execute(ctx context.Context, execCtx *a2asrv.ExecutorContext)
 		runOpts, err := e.runOptions(ctx, contextID)
 		if err != nil {
 			log.Printf("[a2a] session lookup failed for contextID %q: %v", contextID, err)
+		}
+
+		userID := authInfoFromA2AContext(ctx).UserSub
+		if userID == "" {
+			log.Printf("[a2a] no user identity for contextID %q — memory disabled for this turn", contextID)
+		} else if e.mode == ModeAgent {
+			if chunks, memErr := e.mem.Retrieve(ctx, userID, text, e.memTopK); memErr != nil {
+				log.Printf("[a2a] memory retrieve failed for contextID %q: %v", contextID, memErr)
+			} else if len(chunks) > 0 {
+				if runOpts == nil {
+					runOpts = &claude.RunOptions{}
+				}
+				runOpts.AppendSystemPrompt = formatMemoryChunks(chunks)
+			}
 		}
 
 		ch, err := e.prompter.RunWithOptions(ctx, text, runOpts)
@@ -333,13 +360,12 @@ func (e *Executor) releaseContext(contextID string) {
 	delete(e.inFlight, contextID)
 }
 
-// pushTurnAsync fires best-effort kagent history + usage push in a goroutine so
-// the A2A response is not delayed. userText and agentText may be empty (no-op).
+// pushTurnAsync fires best-effort kagent history + usage push and memory
+// recording in a goroutine so the A2A response is not delayed.
+// userText and agentText may be empty (no-op for those operations).
 func (e *Executor) pushTurnAsync(ctx context.Context, execCtx *a2asrv.ExecutorContext, userText, agentText string, messages []claude.StreamMessage) {
-	if e.kagent == nil || !e.kagent.Enabled() {
-		return
-	}
-	if userText == "" && agentText == "" {
+	kagentEnabled := e.kagent != nil && e.kagent.Enabled()
+	if !kagentEnabled && userText == "" && agentText == "" {
 		return
 	}
 
@@ -352,9 +378,24 @@ func (e *Executor) pushTurnAsync(ctx context.Context, execCtx *a2asrv.ExecutorCo
 		pushCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 15*time.Second)
 		defer cancel()
 
-		e.kagent.PushEvent(pushCtx, contextID, kagentapi.NewSessionEvent(taskID+"-user", "user", userText), auth)
-		e.kagent.PushEvent(pushCtx, contextID, kagentapi.NewSessionEventWithMetadata(taskID+"-agent", "agent", agentText, agentMeta), auth)
-		e.kagent.StoreTask(pushCtx, taskID, contextID, userText, agentText, "completed", agentMeta, auth)
+		if kagentEnabled && (userText != "" || agentText != "") {
+			e.kagent.PushEvent(pushCtx, contextID, kagentapi.NewSessionEvent(taskID+"-user", "user", userText), auth)
+			e.kagent.PushEvent(pushCtx, contextID, kagentapi.NewSessionEventWithMetadata(taskID+"-agent", "agent", agentText, agentMeta), auth)
+			e.kagent.StoreTask(pushCtx, taskID, contextID, userText, agentText, "completed", agentMeta, auth)
+		}
+
+		if userID := auth.UserSub; userID != "" {
+			if userText != "" {
+				if err := e.mem.Record(pushCtx, userID, "user", userText); err != nil {
+					log.Printf("[a2a] memory record user failed contextID=%q: %v", contextID, err)
+				}
+			}
+			if agentText != "" {
+				if err := e.mem.Record(pushCtx, userID, "assistant", agentText); err != nil {
+					log.Printf("[a2a] memory record assistant failed contextID=%q: %v", contextID, err)
+				}
+			}
+		}
 	}()
 }
 
@@ -376,6 +417,19 @@ func authInfoFromA2AContext(ctx context.Context) kagentapi.AuthInfo {
 		userSub = vals[0]
 	}
 	return kagentapi.AuthInfo{BearerToken: bearer, UserSub: userSub}
+}
+
+// formatMemoryChunks formats retrieved memory chunks as a system-prompt block
+// that Claude will see before processing the user turn.
+func formatMemoryChunks(chunks []memory.Chunk) string {
+	var sb strings.Builder
+	sb.WriteString("[Relevant memory from previous sessions]\n")
+	for _, c := range chunks {
+		sb.WriteString("- ")
+		sb.WriteString(c.Content)
+		sb.WriteByte('\n')
+	}
+	return sb.String()
 }
 
 // adkUsageMetadata converts a CollectTokenUsage result to the three-field map

--- a/pkg/a2a/executor.go
+++ b/pkg/a2a/executor.go
@@ -17,6 +17,7 @@ import (
 	"github.com/a2aproject/a2a-go/v2/a2asrv"
 
 	"github.com/giantswarm/klaus/pkg/claude"
+	"github.com/giantswarm/klaus/pkg/kagentapi"
 	"github.com/giantswarm/klaus/pkg/telemetry"
 )
 
@@ -36,6 +37,7 @@ const (
 type Executor struct {
 	prompter claude.Prompter
 	mode     Mode
+	kagent   *kagentapi.Client // nil-safe; no-op when endpoint is unset
 
 	mu       sync.Mutex
 	inFlight map[string]struct{}
@@ -45,11 +47,12 @@ type Executor struct {
 var _ a2asrv.AgentExecutor = (*Executor)(nil)
 
 // New returns an Executor. prompter may be a *claude.Process (agent mode) or a
-// *claude.PersistentProcess (chat mode).
-func New(prompter claude.Prompter, mode Mode) *Executor {
+// *claude.PersistentProcess (chat mode). kagentClient may be nil (no-op).
+func New(prompter claude.Prompter, mode Mode, kagentClient *kagentapi.Client) *Executor {
 	return &Executor{
 		prompter: prompter,
 		mode:     mode,
+		kagent:   kagentClient,
 		inFlight: make(map[string]struct{}),
 		sessions: make(map[string]string),
 	}
@@ -184,6 +187,8 @@ func (e *Executor) Execute(ctx context.Context, execCtx *a2asrv.ExecutorContext)
 				return
 			}
 		}
+
+		e.pushTurnAsync(ctx, execCtx, extractText(execCtx.Message), result, messages)
 
 		yield(completedEvent(execCtx), nil)
 	}
@@ -326,4 +331,70 @@ func (e *Executor) releaseContext(contextID string) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	delete(e.inFlight, contextID)
+}
+
+// pushTurnAsync fires best-effort kagent history + usage push in a goroutine so
+// the A2A response is not delayed. userText and agentText may be empty (no-op).
+func (e *Executor) pushTurnAsync(ctx context.Context, execCtx *a2asrv.ExecutorContext, userText, agentText string, messages []claude.StreamMessage) {
+	if e.kagent == nil || !e.kagent.Enabled() {
+		return
+	}
+	if userText == "" && agentText == "" {
+		return
+	}
+
+	contextID := execCtx.ContextID
+	taskID := string(execCtx.TaskID)
+	auth := authInfoFromA2AContext(ctx)
+	agentMeta := adkUsageMetadata(claude.CollectTokenUsage(messages))
+
+	go func() {
+		pushCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+
+		e.kagent.PushEvent(pushCtx, contextID, kagentapi.NewSessionEvent(taskID+"-user", "user", userText), auth)
+		e.kagent.PushEvent(pushCtx, contextID, kagentapi.NewSessionEventWithMetadata(taskID+"-agent", "agent", agentText, agentMeta), auth)
+		e.kagent.StoreTask(pushCtx, taskID, contextID, userText, agentText, "completed", agentMeta, auth)
+	}()
+}
+
+// authInfoFromA2AContext extracts caller identity from the a2asrv CallContext
+// stored in ctx by the JSON-RPC handler. Falls back to SA-token-only auth when
+// absent (e.g. in tests or non-HTTP paths).
+func authInfoFromA2AContext(ctx context.Context) kagentapi.AuthInfo {
+	callCtx, ok := a2asrv.CallContextFrom(ctx)
+	if !ok {
+		return kagentapi.AuthInfo{}
+	}
+	params := callCtx.ServiceParams()
+	var bearer, userSub string
+	if vals, ok := params.Get("authorization"); ok && len(vals) > 0 {
+		bearer = strings.TrimPrefix(vals[0], "Bearer ")
+		bearer = strings.TrimPrefix(bearer, "bearer ")
+	}
+	if vals, ok := params.Get("x-user-id"); ok && len(vals) > 0 {
+		userSub = vals[0]
+	}
+	return kagentapi.AuthInfo{BearerToken: bearer, UserSub: userSub}
+}
+
+// adkUsageMetadata converts a CollectTokenUsage result to the three-field map
+// that kagent's UI reads under the "adk_usage_metadata" key.
+// Returns nil when usage is nil or both input and output are zero.
+func adkUsageMetadata(usage *claude.TokenUsage) map[string]any {
+	if usage == nil {
+		return nil
+	}
+	input := usage.InputTokens
+	output := usage.OutputTokens
+	if input == 0 && output == 0 {
+		return nil
+	}
+	return map[string]any{
+		"adk_usage_metadata": map[string]any{
+			"totalTokenCount":      input + output,
+			"promptTokenCount":     input,
+			"candidatesTokenCount": output,
+		},
+	}
 }

--- a/pkg/a2a/executor_test.go
+++ b/pkg/a2a/executor_test.go
@@ -124,7 +124,7 @@ func makeExecCtx(contextID string, text string) *a2asrv.ExecutorContext {
 
 func TestExecutor_SlashCommandIntercept(t *testing.T) {
 	prompter := &fakePrompter{result: "done"}
-	exec := a2a.New(prompter, a2a.ModeChat, nil)
+	exec := a2a.New(prompter, a2a.ModeChat, nil, nil, 0)
 
 	execCtx := makeExecCtx("ctx-1", "/clear please clear the context")
 	events, err := collectEvents(t.Context(), exec.Execute(t.Context(), execCtx))
@@ -146,7 +146,7 @@ func TestExecutor_SlashCommandIntercept(t *testing.T) {
 
 func TestExecutor_EmptyText(t *testing.T) {
 	prompter := &fakePrompter{}
-	exec := a2a.New(prompter, a2a.ModeChat, nil)
+	exec := a2a.New(prompter, a2a.ModeChat, nil, nil, 0)
 
 	execCtx := makeExecCtx("ctx-2", "")
 
@@ -164,7 +164,7 @@ func TestExecutor_EmptyText(t *testing.T) {
 
 func TestExecutor_BusyReturnsRejected(t *testing.T) {
 	prompter := &fakePrompter{runErr: claude.ErrBusy}
-	exec := a2a.New(prompter, a2a.ModeChat, nil)
+	exec := a2a.New(prompter, a2a.ModeChat, nil, nil, 0)
 
 	execCtx := makeExecCtx("ctx-3", "hello")
 	events, err := collectEvents(t.Context(), exec.Execute(t.Context(), execCtx))
@@ -188,7 +188,7 @@ func TestExecutor_SuccessfulTurn(t *testing.T) {
 			Result:    "The answer is 42.",
 		},
 	}
-	exec := a2a.New(prompter, a2a.ModeChat, nil)
+	exec := a2a.New(prompter, a2a.ModeChat, nil, nil, 0)
 
 	execCtx := makeExecCtx("ctx-4", "What is the answer?")
 	events, err := collectEvents(t.Context(), exec.Execute(t.Context(), execCtx))
@@ -214,7 +214,7 @@ func TestExecutor_ConcurrentContextRejected(t *testing.T) {
 		block:        blocked,
 	}
 
-	exec := a2a.New(blocker, a2a.ModeChat, nil)
+	exec := a2a.New(blocker, a2a.ModeChat, nil, nil, 0)
 
 	// First request: holds the lock. Signal when the first event arrives.
 	ctx1, cancel1 := context.WithCancel(t.Context())
@@ -264,7 +264,7 @@ func TestExecutor_ConcurrentContextRejected(t *testing.T) {
 
 func TestExecutor_Cancel(t *testing.T) {
 	prompter := &fakePrompter{}
-	exec := a2a.New(prompter, a2a.ModeChat, nil)
+	exec := a2a.New(prompter, a2a.ModeChat, nil, nil, 0)
 
 	execCtx := makeExecCtx("ctx-cancel", "")
 	events, err := collectEvents(t.Context(), exec.Cancel(t.Context(), execCtx))
@@ -302,7 +302,7 @@ func TestExecutor_SubprocessError(t *testing.T) {
 			ErrorMessage: "subprocess exited with code 1",
 		},
 	}
-	exec := a2a.New(prompter, a2a.ModeChat, nil)
+	exec := a2a.New(prompter, a2a.ModeChat, nil, nil, 0)
 
 	events, err := collectEvents(t.Context(), exec.Execute(t.Context(), makeExecCtx("ctx-err", "hello")))
 	require.NoError(t, err)
@@ -325,7 +325,7 @@ func TestExecutor_CollectResultTextFallback(t *testing.T) {
 		messages:  []claude.StreamMessage{resultMsg},
 		statusVal: claude.StatusInfo{Status: claude.ProcessStatusIdle},
 	}
-	exec := a2a.New(prompter, a2a.ModeChat, nil)
+	exec := a2a.New(prompter, a2a.ModeChat, nil, nil, 0)
 
 	events, err := collectEvents(t.Context(), exec.Execute(t.Context(), makeExecCtx("ctx-fallback", "hello")))
 	require.NoError(t, err)
@@ -354,7 +354,7 @@ func TestExecutor_AgentModeTracksSubprocessSession(t *testing.T) {
 			Result: "turn result",
 		},
 	}
-	exec := a2a.New(prompter, a2a.ModeAgent, nil)
+	exec := a2a.New(prompter, a2a.ModeAgent, nil, nil, 0)
 
 	// First turn: subprocess reports "subprocess-reported-id".
 	prompter.statusVal.SessionID = "subprocess-reported-id"
@@ -389,7 +389,7 @@ func TestExecutor_AgentModeResume(t *testing.T) {
 			Result:    "turn result",
 		},
 	}
-	exec := a2a.New(prompter, a2a.ModeAgent, nil)
+	exec := a2a.New(prompter, a2a.ModeAgent, nil, nil, 0)
 
 	// First turn — no prior session.
 	events1, err := collectEvents(t.Context(), exec.Execute(t.Context(), makeExecCtx("ctx-resume", "first")))
@@ -480,7 +480,7 @@ func TestExecutor_ArtifactTokenUsage(t *testing.T) {
 				{Type: claude.MessageTypeResult, Result: "answer"},
 			},
 		}
-		exec := a2a.New(fp, a2a.ModeAgent, nil)
+		exec := a2a.New(fp, a2a.ModeAgent, nil, nil, 0)
 		events, err := collectEvents(t.Context(), exec.Execute(t.Context(), makeExecCtx("ctx-usage", "what is 2+2?")))
 		require.NoError(t, err)
 
@@ -501,7 +501,7 @@ func TestExecutor_ArtifactTokenUsage(t *testing.T) {
 
 	t.Run("token_usage absent for slash-command response", func(t *testing.T) {
 		fp := &fakePrompter{}
-		exec := a2a.New(fp, a2a.ModeAgent, nil)
+		exec := a2a.New(fp, a2a.ModeAgent, nil, nil, 0)
 		events, err := collectEvents(t.Context(), exec.Execute(t.Context(), makeExecCtx("ctx-slash", "/clear")))
 		require.NoError(t, err)
 
@@ -523,7 +523,7 @@ func TestExecutor_ArtifactTokenUsage(t *testing.T) {
 func TestExecutor_StaleResumeRetry(t *testing.T) {
 	inner := &fakePrompter{}
 	prompter := &staleResumePrompter{fakePrompter: inner}
-	exec := a2a.New(prompter, a2a.ModeAgent, nil)
+	exec := a2a.New(prompter, a2a.ModeAgent, nil, nil, 0)
 
 	// First turn: fresh start; establishes session "sess-first".
 	_, err := collectEvents(t.Context(), exec.Execute(t.Context(), makeExecCtx("ctx-stale", "first message")))

--- a/pkg/a2a/executor_test.go
+++ b/pkg/a2a/executor_test.go
@@ -124,7 +124,7 @@ func makeExecCtx(contextID string, text string) *a2asrv.ExecutorContext {
 
 func TestExecutor_SlashCommandIntercept(t *testing.T) {
 	prompter := &fakePrompter{result: "done"}
-	exec := a2a.New(prompter, a2a.ModeChat)
+	exec := a2a.New(prompter, a2a.ModeChat, nil)
 
 	execCtx := makeExecCtx("ctx-1", "/clear please clear the context")
 	events, err := collectEvents(t.Context(), exec.Execute(t.Context(), execCtx))
@@ -146,7 +146,7 @@ func TestExecutor_SlashCommandIntercept(t *testing.T) {
 
 func TestExecutor_EmptyText(t *testing.T) {
 	prompter := &fakePrompter{}
-	exec := a2a.New(prompter, a2a.ModeChat)
+	exec := a2a.New(prompter, a2a.ModeChat, nil)
 
 	execCtx := makeExecCtx("ctx-2", "")
 
@@ -164,7 +164,7 @@ func TestExecutor_EmptyText(t *testing.T) {
 
 func TestExecutor_BusyReturnsRejected(t *testing.T) {
 	prompter := &fakePrompter{runErr: claude.ErrBusy}
-	exec := a2a.New(prompter, a2a.ModeChat)
+	exec := a2a.New(prompter, a2a.ModeChat, nil)
 
 	execCtx := makeExecCtx("ctx-3", "hello")
 	events, err := collectEvents(t.Context(), exec.Execute(t.Context(), execCtx))
@@ -188,7 +188,7 @@ func TestExecutor_SuccessfulTurn(t *testing.T) {
 			Result:    "The answer is 42.",
 		},
 	}
-	exec := a2a.New(prompter, a2a.ModeChat)
+	exec := a2a.New(prompter, a2a.ModeChat, nil)
 
 	execCtx := makeExecCtx("ctx-4", "What is the answer?")
 	events, err := collectEvents(t.Context(), exec.Execute(t.Context(), execCtx))
@@ -214,7 +214,7 @@ func TestExecutor_ConcurrentContextRejected(t *testing.T) {
 		block:        blocked,
 	}
 
-	exec := a2a.New(blocker, a2a.ModeChat)
+	exec := a2a.New(blocker, a2a.ModeChat, nil)
 
 	// First request: holds the lock. Signal when the first event arrives.
 	ctx1, cancel1 := context.WithCancel(t.Context())
@@ -264,7 +264,7 @@ func TestExecutor_ConcurrentContextRejected(t *testing.T) {
 
 func TestExecutor_Cancel(t *testing.T) {
 	prompter := &fakePrompter{}
-	exec := a2a.New(prompter, a2a.ModeChat)
+	exec := a2a.New(prompter, a2a.ModeChat, nil)
 
 	execCtx := makeExecCtx("ctx-cancel", "")
 	events, err := collectEvents(t.Context(), exec.Cancel(t.Context(), execCtx))
@@ -302,7 +302,7 @@ func TestExecutor_SubprocessError(t *testing.T) {
 			ErrorMessage: "subprocess exited with code 1",
 		},
 	}
-	exec := a2a.New(prompter, a2a.ModeChat)
+	exec := a2a.New(prompter, a2a.ModeChat, nil)
 
 	events, err := collectEvents(t.Context(), exec.Execute(t.Context(), makeExecCtx("ctx-err", "hello")))
 	require.NoError(t, err)
@@ -325,7 +325,7 @@ func TestExecutor_CollectResultTextFallback(t *testing.T) {
 		messages:  []claude.StreamMessage{resultMsg},
 		statusVal: claude.StatusInfo{Status: claude.ProcessStatusIdle},
 	}
-	exec := a2a.New(prompter, a2a.ModeChat)
+	exec := a2a.New(prompter, a2a.ModeChat, nil)
 
 	events, err := collectEvents(t.Context(), exec.Execute(t.Context(), makeExecCtx("ctx-fallback", "hello")))
 	require.NoError(t, err)
@@ -354,7 +354,7 @@ func TestExecutor_AgentModeTracksSubprocessSession(t *testing.T) {
 			Result: "turn result",
 		},
 	}
-	exec := a2a.New(prompter, a2a.ModeAgent)
+	exec := a2a.New(prompter, a2a.ModeAgent, nil)
 
 	// First turn: subprocess reports "subprocess-reported-id".
 	prompter.statusVal.SessionID = "subprocess-reported-id"
@@ -389,7 +389,7 @@ func TestExecutor_AgentModeResume(t *testing.T) {
 			Result:    "turn result",
 		},
 	}
-	exec := a2a.New(prompter, a2a.ModeAgent)
+	exec := a2a.New(prompter, a2a.ModeAgent, nil)
 
 	// First turn — no prior session.
 	events1, err := collectEvents(t.Context(), exec.Execute(t.Context(), makeExecCtx("ctx-resume", "first")))
@@ -480,7 +480,7 @@ func TestExecutor_ArtifactTokenUsage(t *testing.T) {
 				{Type: claude.MessageTypeResult, Result: "answer"},
 			},
 		}
-		exec := a2a.New(fp, a2a.ModeAgent)
+		exec := a2a.New(fp, a2a.ModeAgent, nil)
 		events, err := collectEvents(t.Context(), exec.Execute(t.Context(), makeExecCtx("ctx-usage", "what is 2+2?")))
 		require.NoError(t, err)
 
@@ -501,7 +501,7 @@ func TestExecutor_ArtifactTokenUsage(t *testing.T) {
 
 	t.Run("token_usage absent for slash-command response", func(t *testing.T) {
 		fp := &fakePrompter{}
-		exec := a2a.New(fp, a2a.ModeAgent)
+		exec := a2a.New(fp, a2a.ModeAgent, nil)
 		events, err := collectEvents(t.Context(), exec.Execute(t.Context(), makeExecCtx("ctx-slash", "/clear")))
 		require.NoError(t, err)
 
@@ -523,7 +523,7 @@ func TestExecutor_ArtifactTokenUsage(t *testing.T) {
 func TestExecutor_StaleResumeRetry(t *testing.T) {
 	inner := &fakePrompter{}
 	prompter := &staleResumePrompter{fakePrompter: inner}
-	exec := a2a.New(prompter, a2a.ModeAgent)
+	exec := a2a.New(prompter, a2a.ModeAgent, nil)
 
 	// First turn: fresh start; establishes session "sess-first".
 	_, err := collectEvents(t.Context(), exec.Execute(t.Context(), makeExecCtx("ctx-stale", "first message")))

--- a/pkg/claude/process.go
+++ b/pkg/claude/process.go
@@ -37,6 +37,9 @@ type RunOptions struct {
 	MaxBudgetUSD float64
 	// Effort overrides Options.Effort for this run.
 	Effort string
+	// AppendSystemPrompt is appended to Options.AppendSystemPrompt for this run.
+	// In persistent (chat) mode this field is ignored and logged as a warning.
+	AppendSystemPrompt string
 }
 
 // ignoredFields returns the names of fields that have non-zero values.
@@ -68,6 +71,9 @@ func (ro *RunOptions) ignoredFields() []string {
 	}
 	if ro.Effort != "" {
 		fields = append(fields, "effort")
+	}
+	if ro.AppendSystemPrompt != "" {
+		fields = append(fields, "append_system_prompt")
 	}
 	return fields
 }
@@ -161,6 +167,12 @@ func (p *Process) mergedOpts(ro *RunOptions) Options {
 	}
 	if ro.Effort != "" {
 		opts.Effort = ro.Effort
+	}
+	if ro.AppendSystemPrompt != "" {
+		if opts.AppendSystemPrompt != "" {
+			opts.AppendSystemPrompt += "\n\n"
+		}
+		opts.AppendSystemPrompt += ro.AppendSystemPrompt
 	}
 	return opts
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -50,6 +50,20 @@ type Config struct {
 
 	// A2A holds settings for outbound A2A calls via the a2a_call MCP tool.
 	A2A A2AConfig `yaml:"a2a"`
+
+	// Kagent holds settings for pushing turn history and usage to the kagent-controller.
+	Kagent KagentConfig `yaml:"kagent"`
+}
+
+// KagentConfig holds settings for the kagent REST push client.
+type KagentConfig struct {
+	// APIEndpoint is the base URL of the kagent-controller REST API.
+	// When empty, push is disabled.
+	// Env: KAGENT_API_ENDPOINT
+	APIEndpoint string `yaml:"apiEndpoint"`
+	// AgentRef is sent as the X-Agent-Name header on push requests.
+	// Env: KAGENT_AGENT_REF
+	AgentRef string `yaml:"agentRef"`
 }
 
 // A2AConfig holds outbound A2A call settings.
@@ -269,6 +283,10 @@ func applyEnvOverrides(cfg *Config) {
 	envOverrideA2ATargets(&cfg.A2A.Targets, "KLAUS_A2A_TARGETS")
 	envOverrideBool(&cfg.A2A.AllowDynamic, "KLAUS_A2A_ALLOW_DYNAMIC")
 	envOverrideCSV(&cfg.A2A.AllowedHosts, "KLAUS_A2A_ALLOWED_HOSTS")
+
+	// kagent history push settings.
+	envOverrideString(&cfg.Kagent.APIEndpoint, "KAGENT_API_ENDPOINT")
+	envOverrideString(&cfg.Kagent.AgentRef, "KAGENT_AGENT_REF")
 
 	// OAuth settings.
 	envOverrideString(&cfg.OAuth.Google.ClientID, "GOOGLE_CLIENT_ID")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -53,6 +53,19 @@ type Config struct {
 
 	// Kagent holds settings for pushing turn history and usage to the kagent-controller.
 	Kagent KagentConfig `yaml:"kagent"`
+
+	// Memory holds settings for per-user cross-session memory.
+	Memory MemoryConfig `yaml:"memory"`
+}
+
+// MemoryConfig holds settings for per-user cross-session memory.
+type MemoryConfig struct {
+	// Enabled turns on cross-session memory retrieval and recording.
+	// Env: MEMORY_ENABLED
+	Enabled bool `yaml:"enabled"`
+	// TopK is the maximum number of memory chunks to inject per turn.
+	// Env: MEMORY_TOP_K (default 5)
+	TopK int `yaml:"topK"`
 }
 
 // KagentConfig holds settings for the kagent REST push client.
@@ -287,6 +300,10 @@ func applyEnvOverrides(cfg *Config) {
 	// kagent history push settings.
 	envOverrideString(&cfg.Kagent.APIEndpoint, "KAGENT_API_ENDPOINT")
 	envOverrideString(&cfg.Kagent.AgentRef, "KAGENT_AGENT_REF")
+
+	// Memory settings.
+	envOverrideBool(&cfg.Memory.Enabled, "MEMORY_ENABLED")
+	envOverrideInt(&cfg.Memory.TopK, "MEMORY_TOP_K")
 
 	// OAuth settings.
 	envOverrideString(&cfg.OAuth.Google.ClientID, "GOOGLE_CLIENT_ID")

--- a/pkg/kagentapi/auth.go
+++ b/pkg/kagentapi/auth.go
@@ -1,0 +1,47 @@
+package kagentapi
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+)
+
+type authContextKey struct{}
+
+// AuthInfo carries the caller's identity forwarded from the inbound A2A request.
+// In-cluster calls fall back to the pod's service-account token when BearerToken is empty.
+type AuthInfo struct {
+	BearerToken string
+	UserSub     string
+}
+
+// WithAuthInfo stores info in ctx.
+func WithAuthInfo(ctx context.Context, info AuthInfo) context.Context {
+	return context.WithValue(ctx, authContextKey{}, info)
+}
+
+// AuthInfoFromContext retrieves AuthInfo from ctx. Returns zero value if absent.
+func AuthInfoFromContext(ctx context.Context) AuthInfo {
+	v, _ := ctx.Value(authContextKey{}).(AuthInfo)
+	return v
+}
+
+// ParseJWTSub decodes a JWT without signature verification and returns the
+// "sub" claim. Returns "" when the token is not a valid three-part JWT or has no sub.
+func ParseJWTSub(token string) string {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return ""
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return ""
+	}
+	var claims map[string]any
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return ""
+	}
+	sub, _ := claims["sub"].(string)
+	return sub
+}

--- a/pkg/kagentapi/client.go
+++ b/pkg/kagentapi/client.go
@@ -190,8 +190,14 @@ func (c *Client) setHeaders(req *http.Request, auth AuthInfo) {
 	if token != "" {
 		req.Header.Set("Authorization", "Bearer "+token)
 	}
-	if auth.UserSub != "" {
-		req.Header.Set("X-User-Id", auth.UserSub)
+	userSub := auth.UserSub
+	if userSub == "" {
+		// kagent /api/sessions/.../events requires X-User-Id.
+		// Fall back to the sub of whichever bearer token we are sending.
+		userSub = ParseJWTSub(token)
+	}
+	if userSub != "" {
+		req.Header.Set("X-User-Id", userSub)
 	}
 	if c.agentRef != "" {
 		req.Header.Set("X-Agent-Name", c.agentRef)

--- a/pkg/kagentapi/client.go
+++ b/pkg/kagentapi/client.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	defaultSATokenPath = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+	defaultSATokenPath = "/var/run/secrets/kubernetes.io/serviceaccount/token" // #nosec G101 -- in-cluster SA token path, not a credential
 	saTokenCacheTTL    = 5 * time.Minute
 	httpTimeout        = 10 * time.Second
 
@@ -174,7 +174,7 @@ func (c *Client) post(ctx context.Context, endpoint string, body any, auth AuthI
 		slog.WarnContext(ctx, "kagentapi: request failed", "url", endpoint, "error", err)
 		return
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode >= http.StatusBadRequest {
 		slog.WarnContext(ctx, "kagentapi: unexpected status", "url", endpoint, "status", resp.StatusCode)
 	}

--- a/pkg/kagentapi/client.go
+++ b/pkg/kagentapi/client.go
@@ -1,0 +1,226 @@
+// Package kagentapi provides a best-effort REST client for pushing turn history
+// and token usage to the kagent-controller after each A2A turn.
+package kagentapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	defaultSATokenPath = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+	saTokenCacheTTL    = 5 * time.Minute
+	httpTimeout        = 10 * time.Second
+
+	kindMessage = "message"
+	kindText    = "text"
+)
+
+// Client pushes turn history and token usage to the kagent-controller REST API.
+// All operations are best-effort: errors are logged and never returned.
+// A zero-endpoint Client is valid and disables all operations.
+type Client struct {
+	endpoint    string
+	agentRef    string
+	httpClient  *http.Client
+	saTokenPath string
+
+	saTokenMu     sync.RWMutex
+	saTokenCached string
+	saTokenExpiry time.Time
+}
+
+// New returns a Client. When endpoint is empty the client is disabled and all
+// methods are no-ops.
+func New(endpoint, agentRef string) *Client {
+	return &Client{
+		endpoint:    endpoint,
+		agentRef:    agentRef,
+		httpClient:  &http.Client{Timeout: httpTimeout},
+		saTokenPath: defaultSATokenPath,
+	}
+}
+
+// Enabled returns true when the client has a non-empty endpoint.
+func (c *Client) Enabled() bool {
+	return c.endpoint != ""
+}
+
+// wire types matching the kagent-controller REST API -------------------------
+
+type a2aMessage struct {
+	Kind      string         `json:"kind"`
+	MessageID string         `json:"messageId"`
+	Role      string         `json:"role"`
+	Parts     []a2aPart      `json:"parts"`
+	Metadata  map[string]any `json:"metadata,omitempty"`
+}
+
+type a2aPart struct {
+	Kind string `json:"kind"`
+	Text string `json:"text"`
+}
+
+type a2aTask struct {
+	Kind      string        `json:"kind"`
+	ID        string        `json:"id"`
+	ContextID string        `json:"contextId"`
+	Status    a2aTaskStatus `json:"status"`
+	History   []a2aMessage  `json:"history,omitempty"`
+}
+
+type a2aTaskStatus struct {
+	State     string `json:"state"`
+	Timestamp string `json:"timestamp,omitempty"`
+}
+
+// SessionEvent is a single event posted to /api/sessions/{id}/events.
+// Data is a double-encoded JSON string containing a serialised a2aMessage.
+type SessionEvent struct {
+	ID   string `json:"id"`
+	Data string `json:"data"`
+}
+
+// NewSessionEvent builds a SessionEvent with no metadata.
+func NewSessionEvent(id, role, text string) SessionEvent {
+	return NewSessionEventWithMetadata(id, role, text, nil)
+}
+
+// NewSessionEventWithMetadata builds a SessionEvent with arbitrary metadata on
+// the inner a2aMessage. metadata may be nil.
+func NewSessionEventWithMetadata(id, role, text string, metadata map[string]any) SessionEvent {
+	msg := a2aMessage{
+		Kind:      kindMessage,
+		MessageID: id,
+		Role:      role,
+		Parts:     []a2aPart{{Kind: kindText, Text: text}},
+		Metadata:  metadata,
+	}
+	data, _ := json.Marshal(msg)
+	return SessionEvent{ID: id, Data: string(data)}
+}
+
+// PushEvent posts a session event to /api/sessions/{contextID}/events.
+// The call is best-effort; errors are logged and not returned.
+func (c *Client) PushEvent(ctx context.Context, contextID string, event SessionEvent, auth AuthInfo) {
+	if !c.Enabled() {
+		return
+	}
+	endpoint := fmt.Sprintf("%s/api/sessions/%s/events", c.endpoint, url.PathEscape(contextID))
+	c.post(ctx, endpoint, event, auth)
+}
+
+// StoreTask upserts a completed task at /api/tasks. The agent message carries
+// agentMetadata (usage, etc.) when non-nil.
+// The call is best-effort; errors are logged and not returned.
+func (c *Client) StoreTask(ctx context.Context, taskID, contextID, userText, agentText, state string, agentMetadata map[string]any, auth AuthInfo) {
+	if !c.Enabled() {
+		return
+	}
+	task := a2aTask{
+		Kind:      "task",
+		ID:        taskID,
+		ContextID: contextID,
+		Status: a2aTaskStatus{
+			State:     state,
+			Timestamp: time.Now().UTC().Format(time.RFC3339),
+		},
+		History: []a2aMessage{
+			{
+				Kind:      kindMessage,
+				MessageID: taskID + "-user",
+				Role:      "user",
+				Parts:     []a2aPart{{Kind: kindText, Text: userText}},
+			},
+			{
+				Kind:      kindMessage,
+				MessageID: taskID + "-agent",
+				Role:      "agent",
+				Parts:     []a2aPart{{Kind: kindText, Text: agentText}},
+				Metadata:  agentMetadata,
+			},
+		},
+	}
+	endpoint := fmt.Sprintf("%s/api/tasks", c.endpoint)
+	c.post(ctx, endpoint, task, auth)
+}
+
+// post marshals body as JSON and POSTs it to endpoint. Errors are logged.
+func (c *Client) post(ctx context.Context, endpoint string, body any, auth AuthInfo) {
+	data, err := json.Marshal(body)
+	if err != nil {
+		slog.WarnContext(ctx, "kagentapi: marshal failed", "url", endpoint, "error", err)
+		return
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(data))
+	if err != nil {
+		slog.WarnContext(ctx, "kagentapi: build request failed", "url", endpoint, "error", err)
+		return
+	}
+	c.setHeaders(req, auth)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		slog.WarnContext(ctx, "kagentapi: request failed", "url", endpoint, "error", err)
+		return
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= http.StatusBadRequest {
+		slog.WarnContext(ctx, "kagentapi: unexpected status", "url", endpoint, "status", resp.StatusCode)
+	}
+}
+
+// setHeaders attaches auth and content-type headers to req.
+func (c *Client) setHeaders(req *http.Request, auth AuthInfo) {
+	req.Header.Set("Content-Type", "application/json")
+	token := auth.BearerToken
+	if token == "" {
+		token = c.readServiceAccountToken()
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	if auth.UserSub != "" {
+		req.Header.Set("X-User-Id", auth.UserSub)
+	}
+	if c.agentRef != "" {
+		req.Header.Set("X-Agent-Name", c.agentRef)
+	}
+}
+
+// readServiceAccountToken reads and caches the pod's SA token for up to
+// saTokenCacheTTL. Returns "" on error.
+func (c *Client) readServiceAccountToken() string {
+	c.saTokenMu.RLock()
+	if c.saTokenCached != "" && time.Now().Before(c.saTokenExpiry) {
+		token := c.saTokenCached
+		c.saTokenMu.RUnlock()
+		return token
+	}
+	c.saTokenMu.RUnlock()
+
+	c.saTokenMu.Lock()
+	defer c.saTokenMu.Unlock()
+	// Re-check under write lock.
+	if c.saTokenCached != "" && time.Now().Before(c.saTokenExpiry) {
+		return c.saTokenCached
+	}
+	data, err := os.ReadFile(c.saTokenPath)
+	if err != nil {
+		return ""
+	}
+	token := strings.TrimSpace(string(data))
+	c.saTokenCached = token
+	c.saTokenExpiry = time.Now().Add(saTokenCacheTTL)
+	return token
+}

--- a/pkg/kagentapi/client.go
+++ b/pkg/kagentapi/client.go
@@ -41,12 +41,21 @@ type Client struct {
 
 // New returns a Client. When endpoint is empty the client is disabled and all
 // methods are no-ops.
+//
+// If the environment variable KAGENT_SA_TOKEN_PATH is set, its value overrides
+// the default SA token path. Set it to the mount point of a projected
+// ServiceAccountToken volume (audience: kagent) to avoid relying on the
+// default automounted token.
 func New(endpoint, agentRef string) *Client {
+	tokenPath := defaultSATokenPath
+	if override := os.Getenv("KAGENT_SA_TOKEN_PATH"); override != "" {
+		tokenPath = override
+	}
 	return &Client{
 		endpoint:    endpoint,
 		agentRef:    agentRef,
 		httpClient:  &http.Client{Timeout: httpTimeout},
-		saTokenPath: defaultSATokenPath,
+		saTokenPath: tokenPath,
 	}
 }
 

--- a/pkg/kagentapi/client_test.go
+++ b/pkg/kagentapi/client_test.go
@@ -1,0 +1,191 @@
+package kagentapi_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/giantswarm/klaus/pkg/kagentapi"
+)
+
+func TestDisabled(t *testing.T) {
+	client := kagentapi.New("", "")
+	require.False(t, client.Enabled())
+
+	// All operations must be no-ops (would panic/error if they attempted HTTP).
+	client.PushEvent(t.Context(), "ctx1", kagentapi.NewSessionEvent("id1", "user", "hello"), kagentapi.AuthInfo{})
+	client.StoreTask(t.Context(), "task1", "ctx1", "hello", "world", "completed", nil, kagentapi.AuthInfo{})
+}
+
+func TestPushEvent_URL(t *testing.T) {
+	contextID := "ctx-abc/def" // contains slash — must be path-escaped
+	var capturedURL string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedURL = r.URL.String()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	client := kagentapi.New(srv.URL, "")
+	client.PushEvent(t.Context(), contextID, kagentapi.NewSessionEvent("id1", "user", "hello"), kagentapi.AuthInfo{})
+
+	want := "/api/sessions/" + url.PathEscape(contextID) + "/events"
+	require.Equal(t, want, capturedURL)
+}
+
+func TestPushEvent_DoubleEncodedData(t *testing.T) {
+	var body map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		data, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.NoError(t, json.Unmarshal(data, &body))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	event := kagentapi.NewSessionEventWithMetadata("id1", "agent", "hi", map[string]any{
+		"adk_usage_metadata": map[string]any{
+			"totalTokenCount":      100,
+			"promptTokenCount":     80,
+			"candidatesTokenCount": 20,
+		},
+	})
+	client := kagentapi.New(srv.URL, "")
+	client.PushEvent(t.Context(), "ctx1", event, kagentapi.AuthInfo{})
+
+	// data field must be a JSON string (double-encoded)
+	dataStr, ok := body["data"].(string)
+	require.True(t, ok, "data must be a JSON string, got %T", body["data"])
+
+	var inner map[string]any
+	require.NoError(t, json.Unmarshal([]byte(dataStr), &inner))
+	require.Equal(t, "message", inner["kind"])
+	require.Equal(t, "agent", inner["role"])
+
+	meta, ok := inner["metadata"].(map[string]any)
+	require.True(t, ok)
+	usage, ok := meta["adk_usage_metadata"].(map[string]any)
+	require.True(t, ok)
+	require.EqualValues(t, 100, usage["totalTokenCount"])
+	require.EqualValues(t, 80, usage["promptTokenCount"])
+	require.EqualValues(t, 20, usage["candidatesTokenCount"])
+}
+
+func TestStoreTask_URL(t *testing.T) {
+	var capturedURL string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedURL = r.URL.String()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	client := kagentapi.New(srv.URL, "")
+	client.StoreTask(t.Context(), "task1", "ctx1", "hello", "world", "completed", nil, kagentapi.AuthInfo{})
+
+	require.Equal(t, "/api/tasks", capturedURL)
+}
+
+func TestStoreTask_Body(t *testing.T) {
+	var body map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		data, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.NoError(t, json.Unmarshal(data, &body))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	agentMeta := map[string]any{
+		"adk_usage_metadata": map[string]any{
+			"totalTokenCount":      50,
+			"promptTokenCount":     30,
+			"candidatesTokenCount": 20,
+		},
+	}
+	client := kagentapi.New(srv.URL, "")
+	client.StoreTask(t.Context(), "task42", "ctx99", "user says hi", "agent says bye", "completed", agentMeta, kagentapi.AuthInfo{})
+
+	require.Equal(t, "task", body["kind"])
+	require.Equal(t, "task42", body["id"])
+	require.Equal(t, "ctx99", body["contextId"])
+
+	history, ok := body["history"].([]any)
+	require.True(t, ok)
+	require.Len(t, history, 2)
+
+	userMsg, ok := history[0].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "user", userMsg["role"])
+
+	agentMsg, ok := history[1].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "agent", agentMsg["role"])
+
+	meta, ok := agentMsg["metadata"].(map[string]any)
+	require.True(t, ok)
+	_, hasUsage := meta["adk_usage_metadata"]
+	require.True(t, hasUsage)
+
+	// user message must not carry metadata
+	_, hasUserMeta := userMsg["metadata"]
+	require.False(t, hasUserMeta, "user message must not carry metadata")
+}
+
+func TestHeaders_Auth(t *testing.T) {
+	var gotHeaders http.Header
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHeaders = r.Header
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	client := kagentapi.New(srv.URL, "my-agent")
+	auth := kagentapi.AuthInfo{BearerToken: "tok123", UserSub: "user@example.com"}
+	client.PushEvent(t.Context(), "ctx1", kagentapi.NewSessionEvent("id1", "user", "hi"), auth)
+
+	require.Equal(t, "application/json", gotHeaders.Get("Content-Type"))
+	require.Equal(t, "Bearer tok123", gotHeaders.Get("Authorization"))
+	require.Equal(t, "user@example.com", gotHeaders.Get("X-User-Id"))
+	require.Equal(t, "my-agent", gotHeaders.Get("X-Agent-Name"))
+}
+
+func TestHeaders_NoUserSub(t *testing.T) {
+	var gotHeaders http.Header
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHeaders = r.Header
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	client := kagentapi.New(srv.URL, "")
+	client.PushEvent(t.Context(), "ctx1", kagentapi.NewSessionEvent("id1", "user", "hi"), kagentapi.AuthInfo{BearerToken: "tok"})
+
+	require.Empty(t, gotHeaders.Get("X-User-Id"))
+	require.Empty(t, gotHeaders.Get("X-Agent-Name"))
+	require.Equal(t, "Bearer tok", gotHeaders.Get("Authorization"))
+}
+
+func TestPushEvent_ContentType(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	kagentapi.New(srv.URL, "").PushEvent(t.Context(), "ctx", kagentapi.NewSessionEvent("id", "user", "x"), kagentapi.AuthInfo{})
+}
+
+func TestNewSessionEvent_NoMetadata(t *testing.T) {
+	ev := kagentapi.NewSessionEvent("id1", "user", "hello")
+	require.Equal(t, "id1", ev.ID)
+	require.True(t, strings.Contains(ev.Data, `"role":"user"`))
+	require.True(t, strings.Contains(ev.Data, `"hello"`))
+	// No metadata key in data.
+	require.False(t, strings.Contains(ev.Data, "metadata"))
+}

--- a/pkg/kagentapi/client_test.go
+++ b/pkg/kagentapi/client_test.go
@@ -1,6 +1,7 @@
 package kagentapi_test
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -155,7 +156,30 @@ func TestHeaders_Auth(t *testing.T) {
 	require.Equal(t, "my-agent", gotHeaders.Get("X-Agent-Name"))
 }
 
-func TestHeaders_NoUserSub(t *testing.T) {
+func TestHeaders_NoUserSub_PlainToken(t *testing.T) {
+	var gotHeaders http.Header
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHeaders = r.Header
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	// Plain opaque token — ParseJWTSub returns ""; no X-User-Id is sent.
+	client := kagentapi.New(srv.URL, "")
+	client.PushEvent(t.Context(), "ctx1", kagentapi.NewSessionEvent("id1", "user", "hi"), kagentapi.AuthInfo{BearerToken: "tok"})
+
+	require.Empty(t, gotHeaders.Get("X-User-Id"))
+	require.Empty(t, gotHeaders.Get("X-Agent-Name"))
+	require.Equal(t, "Bearer tok", gotHeaders.Get("Authorization"))
+}
+
+func TestHeaders_UserSubFallbackFromJWT(t *testing.T) {
+	// Build a minimal unsigned JWT with sub="alice@example.com".
+	// kagent requires X-User-Id; the client falls back to ParseJWTSub(token).
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none"}`))
+	payload := base64.RawURLEncoding.EncodeToString([]byte(`{"sub":"alice@example.com"}`))
+	jwtToken := header + "." + payload + ".sig"
+
 	var gotHeaders http.Header
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotHeaders = r.Header
@@ -164,11 +188,10 @@ func TestHeaders_NoUserSub(t *testing.T) {
 	defer srv.Close()
 
 	client := kagentapi.New(srv.URL, "")
-	client.PushEvent(t.Context(), "ctx1", kagentapi.NewSessionEvent("id1", "user", "hi"), kagentapi.AuthInfo{BearerToken: "tok"})
+	client.PushEvent(t.Context(), "ctx1", kagentapi.NewSessionEvent("id1", "user", "hi"), kagentapi.AuthInfo{BearerToken: jwtToken})
 
-	require.Empty(t, gotHeaders.Get("X-User-Id"))
-	require.Empty(t, gotHeaders.Get("X-Agent-Name"))
-	require.Equal(t, "Bearer tok", gotHeaders.Get("Authorization"))
+	require.Equal(t, "alice@example.com", gotHeaders.Get("X-User-Id"))
+	require.Equal(t, "Bearer "+jwtToken, gotHeaders.Get("Authorization"))
 }
 
 func TestPushEvent_ContentType(t *testing.T) {

--- a/pkg/kagentapi/client_test.go
+++ b/pkg/kagentapi/client_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -192,6 +194,28 @@ func TestHeaders_UserSubFallbackFromJWT(t *testing.T) {
 
 	require.Equal(t, "alice@example.com", gotHeaders.Get("X-User-Id"))
 	require.Equal(t, "Bearer "+jwtToken, gotHeaders.Get("Authorization"))
+}
+
+func TestSATokenPath_FromEnv(t *testing.T) {
+	// Write a token to a temp file and point KAGENT_SA_TOKEN_PATH at it.
+	// New() must read from that path instead of the default SA token path.
+	dir := t.TempDir()
+	tokenFile := filepath.Join(dir, "token")
+	require.NoError(t, os.WriteFile(tokenFile, []byte("projected-kagent-token"), 0600))
+
+	t.Setenv("KAGENT_SA_TOKEN_PATH", tokenFile)
+
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	// No BearerToken supplied — must fall back to the SA token file.
+	kagentapi.New(srv.URL, "").PushEvent(t.Context(), "ctx", kagentapi.NewSessionEvent("id", "user", "x"), kagentapi.AuthInfo{})
+
+	require.Equal(t, "Bearer projected-kagent-token", gotAuth)
 }
 
 func TestPushEvent_ContentType(t *testing.T) {

--- a/pkg/memory/embedding.go
+++ b/pkg/memory/embedding.go
@@ -1,0 +1,107 @@
+package memory
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"net/http"
+	"os"
+	"time"
+)
+
+const embeddingDim = 768
+
+// embeddingClient calls an OpenAI-compatible embedding endpoint.
+// Compatible with OpenAI, vLLM, Ollama (via its /v1 proxy), and any other
+// OpenAI-spec embedding server. Returns exactly 768-dim float32 vectors
+// (truncated if the model produces more, with L2 re-normalization).
+type embeddingClient struct {
+	endpoint   string
+	model      string
+	apiKey     string
+	httpClient *http.Client
+}
+
+func newEmbeddingClientFromEnv() *embeddingClient {
+	endpoint := os.Getenv("KLAUS_EMBEDDING_ENDPOINT")
+	if endpoint == "" {
+		endpoint = "https://api.openai.com/v1"
+	}
+	return &embeddingClient{
+		endpoint:   endpoint,
+		model:      os.Getenv("KLAUS_EMBEDDING_MODEL"),
+		apiKey:     os.Getenv("KLAUS_EMBEDDING_API_KEY"),
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+func (c *embeddingClient) enabled() bool {
+	return c.model != ""
+}
+
+func (c *embeddingClient) embed(ctx context.Context, text string) ([]float32, error) {
+	body, err := json.Marshal(map[string]any{
+		"model": c.model,
+		"input": []string{text},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal embedding request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpoint+"/embeddings", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("build embedding request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if c.apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("embedding request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("embedding API returned HTTP %d", resp.StatusCode)
+	}
+
+	var result struct {
+		Data []struct {
+			Embedding []float32 `json:"embedding"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decode embedding response: %w", err)
+	}
+	if len(result.Data) == 0 || len(result.Data[0].Embedding) == 0 {
+		return nil, fmt.Errorf("empty embedding response from %s", c.endpoint)
+	}
+
+	return truncateAndNormalize(result.Data[0].Embedding, embeddingDim), nil
+}
+
+// truncateAndNormalize truncates vec to dim elements and re-applies L2 normalization.
+// Truncation without re-normalization produces a vector that is no longer unit-length,
+// which degrades cosine similarity scores in the vector store.
+func truncateAndNormalize(vec []float32, dim int) []float32 {
+	if len(vec) > dim {
+		vec = vec[:dim]
+	}
+	var sum float64
+	for _, v := range vec {
+		sum += float64(v) * float64(v)
+	}
+	norm := float32(math.Sqrt(sum))
+	if norm == 0 {
+		return vec
+	}
+	out := make([]float32, len(vec))
+	for i, v := range vec {
+		out[i] = v / norm
+	}
+	return out
+}

--- a/pkg/memory/factory.go
+++ b/pkg/memory/factory.go
@@ -1,0 +1,29 @@
+package memory
+
+import "os"
+
+// New returns a Store backed by the kagent memory API.
+// Returns NoOp when MEMORY_ENABLED is not set, endpoint is empty,
+// or KLAUS_EMBEDDING_MODEL is unset (vectors cannot be generated).
+func New(endpoint, agentName string) Store {
+	if !parseBoolEnv("MEMORY_ENABLED") {
+		return NoOp{}
+	}
+	if endpoint == "" {
+		return NoOp{}
+	}
+	embedder := newEmbeddingClientFromEnv()
+	if !embedder.enabled() {
+		return NoOp{}
+	}
+	return newKagentStore(endpoint, agentName, embedder)
+}
+
+func parseBoolEnv(key string) bool {
+	switch os.Getenv(key) {
+	case "true", "1", "yes":
+		return true
+	default:
+		return false
+	}
+}

--- a/pkg/memory/kagent.go
+++ b/pkg/memory/kagent.go
@@ -1,0 +1,149 @@
+package memory
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"time"
+)
+
+// KagentStore implements Store against the kagent pgvector memory API.
+// All vectors are generated locally by embeddingClient — the kagent controller
+// does not embed; it stores and searches raw float32 vectors supplied by the caller.
+//
+// API:
+//
+//	POST /api/memories/sessions — store a content+vector pair
+//	POST /api/memories/search   — vector similarity search
+//
+// Both endpoints require X-User-ID for internal-trust auth.
+type KagentStore struct {
+	endpoint   string
+	agentName  string
+	embedder   *embeddingClient
+	httpClient *http.Client
+	log        *slog.Logger
+}
+
+var _ Store = (*KagentStore)(nil)
+
+func newKagentStore(endpoint, agentName string, embedder *embeddingClient) *KagentStore {
+	return &KagentStore{
+		endpoint:   endpoint,
+		agentName:  agentName,
+		embedder:   embedder,
+		httpClient: &http.Client{Timeout: 10 * time.Second},
+		log:        slog.Default().With("component", "memory.kagent"),
+	}
+}
+
+type kagentAddRequest struct {
+	AgentName string    `json:"agent_name"`
+	UserID    string    `json:"user_id"`
+	Content   string    `json:"content"`
+	Vector    []float32 `json:"vector"`
+	TTLDays   int       `json:"ttl_days,omitempty"`
+}
+
+type kagentSearchRequest struct {
+	AgentName string    `json:"agent_name"`
+	UserID    string    `json:"user_id"`
+	Vector    []float32 `json:"vector"`
+	Limit     int       `json:"limit"`
+	MinScore  float64   `json:"min_score"`
+}
+
+type kagentSearchResult struct {
+	ID      string  `json:"id"`
+	Content string  `json:"content"`
+	Score   float64 `json:"score"`
+}
+
+// Retrieve searches the kagent memory store for the top-K most relevant chunks
+// for the given userID and query.
+func (s *KagentStore) Retrieve(ctx context.Context, userID, query string, topK int) ([]Chunk, error) {
+	vector, err := s.embedder.embed(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("embed query: %w", err)
+	}
+
+	body, err := json.Marshal(kagentSearchRequest{
+		AgentName: s.agentName,
+		UserID:    userID,
+		Vector:    vector,
+		Limit:     topK,
+		MinScore:  0.3,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal search request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.endpoint+"/api/memories/search", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("build search request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-User-ID", userID)
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("search request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("memory search returned HTTP %d", resp.StatusCode)
+	}
+
+	var items []kagentSearchResult
+	if err := json.NewDecoder(resp.Body).Decode(&items); err != nil {
+		return nil, fmt.Errorf("decode search response: %w", err)
+	}
+
+	chunks := make([]Chunk, 0, len(items))
+	for _, item := range items {
+		chunks = append(chunks, Chunk{Content: item.Content, Score: float32(item.Score)})
+	}
+	return chunks, nil
+}
+
+// Record persists a turn utterance to the kagent memory store.
+// The role is prepended to content to preserve speaker attribution.
+func (s *KagentStore) Record(ctx context.Context, userID, role, content string) error {
+	text := role + ": " + content
+	vector, err := s.embedder.embed(ctx, text)
+	if err != nil {
+		return fmt.Errorf("embed content: %w", err)
+	}
+
+	body, err := json.Marshal(kagentAddRequest{
+		AgentName: s.agentName,
+		UserID:    userID,
+		Content:   text,
+		Vector:    vector,
+	})
+	if err != nil {
+		return fmt.Errorf("marshal store request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.endpoint+"/api/memories/sessions", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("build store request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-User-ID", userID)
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("store request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("memory store returned HTTP %d", resp.StatusCode)
+	}
+	return nil
+}

--- a/pkg/memory/kagent_test.go
+++ b/pkg/memory/kagent_test.go
@@ -1,0 +1,116 @@
+package memory
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestKagentStore_Retrieve(t *testing.T) {
+	embSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/embeddings", r.URL.Path)
+		vec := make([]float32, embeddingDim)
+		vec[0] = 1.0
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": []map[string]any{{"embedding": vec}},
+		})
+	}))
+	defer embSrv.Close()
+
+	results := []kagentSearchResult{
+		{ID: "1", Content: "user: hello from last session", Score: 0.9},
+		{ID: "2", Content: "assistant: hi there", Score: 0.8},
+	}
+	memSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/memories/search", r.URL.Path)
+		require.Equal(t, "alice", r.Header.Get("X-User-ID"))
+
+		var req kagentSearchRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		require.Equal(t, "alice", req.UserID)
+		require.Equal(t, "myagent", req.AgentName)
+		require.Equal(t, 5, req.Limit)
+		require.Len(t, req.Vector, embeddingDim)
+
+		_ = json.NewEncoder(w).Encode(results)
+	}))
+	defer memSrv.Close()
+
+	embedder := &embeddingClient{
+		endpoint:   embSrv.URL,
+		model:      "test-model",
+		httpClient: &http.Client{Timeout: 5 * time.Second},
+	}
+	store := newKagentStore(memSrv.URL, "myagent", embedder)
+
+	chunks, err := store.Retrieve(t.Context(), "alice", "hello", 5)
+	require.NoError(t, err)
+	require.Len(t, chunks, 2)
+	require.Equal(t, "user: hello from last session", chunks[0].Content)
+	require.InDelta(t, 0.9, chunks[0].Score, 0.01)
+}
+
+func TestKagentStore_Record(t *testing.T) {
+	embSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		vec := make([]float32, embeddingDim)
+		vec[0] = 1.0
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": []map[string]any{{"embedding": vec}},
+		})
+	}))
+	defer embSrv.Close()
+
+	var recorded kagentAddRequest
+	memSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/memories/sessions", r.URL.Path)
+		require.Equal(t, "bob", r.Header.Get("X-User-ID"))
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&recorded))
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer memSrv.Close()
+
+	embedder := &embeddingClient{
+		endpoint:   embSrv.URL,
+		model:      "test-model",
+		httpClient: &http.Client{Timeout: 5 * time.Second},
+	}
+	store := newKagentStore(memSrv.URL, "myagent", embedder)
+
+	err := store.Record(t.Context(), "bob", "user", "what is the capital of France?")
+	require.NoError(t, err)
+	require.Equal(t, "bob", recorded.UserID)
+	require.Equal(t, "myagent", recorded.AgentName)
+	require.Equal(t, "user: what is the capital of France?", recorded.Content)
+	require.Len(t, recorded.Vector, embeddingDim)
+}
+
+func TestKagentStore_SearchError(t *testing.T) {
+	embSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		vec := make([]float32, embeddingDim)
+		vec[0] = 1.0
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": []map[string]any{{"embedding": vec}},
+		})
+	}))
+	defer embSrv.Close()
+
+	memSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer memSrv.Close()
+
+	embedder := &embeddingClient{
+		endpoint:   embSrv.URL,
+		model:      "test-model",
+		httpClient: &http.Client{Timeout: 5 * time.Second},
+	}
+	store := newKagentStore(memSrv.URL, "myagent", embedder)
+
+	_, err := store.Retrieve(t.Context(), "alice", "hello", 5)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "HTTP 500")
+}

--- a/pkg/memory/store.go
+++ b/pkg/memory/store.go
@@ -1,0 +1,41 @@
+// Package memory provides per-user cross-session recall for Klaus.
+// On each A2A turn the executor retrieves relevant chunks from previous
+// conversations and injects them into the system prompt; after the turn it
+// records both sides of the exchange attributed to the caller's identity.
+//
+// The identity key is the JWT sub (UserSub), never the contextID — so memory
+// survives across sessions that mint a fresh contextID on every conversation.
+//
+// Required env for kagent backend:
+//   - MEMORY_ENABLED=true
+//   - KAGENT_API_ENDPOINT       — already required for kagent push
+//   - KAGENT_AGENT_REF          — already required for kagent push
+//   - KLAUS_EMBEDDING_ENDPOINT  — OpenAI-compatible embedding base URL
+//   - KLAUS_EMBEDDING_MODEL     — embedding model name
+//   - KLAUS_EMBEDDING_API_KEY   — API key (omit for unauthenticated endpoints)
+package memory
+
+import "context"
+
+// Chunk is a single memory fragment retrieved for a query.
+type Chunk struct {
+	Content string
+	Score   float32
+}
+
+// Store retrieves and records per-user conversation memory across sessions.
+// Implementations must be safe for concurrent use.
+type Store interface {
+	// Retrieve returns the top-K most relevant Chunks for userID.
+	Retrieve(ctx context.Context, userID, query string, topK int) ([]Chunk, error)
+	// Record persists one turn utterance attributed to userID.
+	Record(ctx context.Context, userID, role, content string) error
+}
+
+// NoOp is a Store that silently discards all writes and returns empty results.
+type NoOp struct{}
+
+var _ Store = NoOp{}
+
+func (NoOp) Retrieve(_ context.Context, _, _ string, _ int) ([]Chunk, error) { return nil, nil }
+func (NoOp) Record(_ context.Context, _, _, _ string) error                   { return nil }

--- a/pkg/memory/store.go
+++ b/pkg/memory/store.go
@@ -38,4 +38,4 @@ type NoOp struct{}
 var _ Store = NoOp{}
 
 func (NoOp) Retrieve(_ context.Context, _, _ string, _ int) ([]Chunk, error) { return nil, nil }
-func (NoOp) Record(_ context.Context, _, _, _ string) error                   { return nil }
+func (NoOp) Record(_ context.Context, _, _, _ string) error                  { return nil }

--- a/pkg/memory/store_test.go
+++ b/pkg/memory/store_test.go
@@ -1,0 +1,93 @@
+package memory
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNoOp(t *testing.T) {
+	var s Store = NoOp{}
+
+	chunks, err := s.Retrieve(t.Context(), "alice", "query", 5)
+	require.NoError(t, err)
+	require.Empty(t, chunks)
+
+	err = s.Record(t.Context(), "alice", "user", "hello")
+	require.NoError(t, err)
+}
+
+func TestTruncateAndNormalize(t *testing.T) {
+	tests := []struct {
+		name string
+		vec  []float32
+		dim  int
+	}{
+		{
+			name: "truncation reduces length",
+			vec:  []float32{3, 4, 0},
+			dim:  2,
+		},
+		{
+			name: "no truncation needed",
+			vec:  []float32{1, 0},
+			dim:  4,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := truncateAndNormalize(tc.vec, tc.dim)
+
+			expectedLen := tc.dim
+			if len(tc.vec) < tc.dim {
+				expectedLen = len(tc.vec)
+			}
+			require.Len(t, result, expectedLen)
+
+			// Check unit length (L2 norm == 1).
+			var sumSq float64
+			for _, v := range result {
+				sumSq += float64(v) * float64(v)
+			}
+			require.InDelta(t, 1.0, sumSq, 1e-5)
+		})
+	}
+}
+
+func TestTruncateAndNormalize_ZeroVector(t *testing.T) {
+	vec := make([]float32, 4)
+	result := truncateAndNormalize(vec, 4)
+	require.Len(t, result, 4)
+}
+
+func TestFactory_NoopWhenDisabled(t *testing.T) {
+	t.Setenv("MEMORY_ENABLED", "false")
+	s := New("http://kagent:9090", "myagent")
+	_, isNoOp := s.(NoOp)
+	require.True(t, isNoOp, "expected NoOp when MEMORY_ENABLED=false")
+}
+
+func TestFactory_NoopWhenNoModel(t *testing.T) {
+	t.Setenv("MEMORY_ENABLED", "true")
+	t.Setenv("KLAUS_EMBEDDING_MODEL", "")
+	s := New("http://kagent:9090", "myagent")
+	_, isNoOp := s.(NoOp)
+	require.True(t, isNoOp, "expected NoOp when KLAUS_EMBEDDING_MODEL is unset")
+}
+
+func TestFactory_NoopWhenNoEndpoint(t *testing.T) {
+	t.Setenv("MEMORY_ENABLED", "true")
+	t.Setenv("KLAUS_EMBEDDING_MODEL", "text-embedding-3-small")
+	s := New("", "myagent")
+	_, isNoOp := s.(NoOp)
+	require.True(t, isNoOp, "expected NoOp when endpoint is empty")
+}
+
+func TestFactory_KagentStoreWhenFullyConfigured(t *testing.T) {
+	t.Setenv("MEMORY_ENABLED", "true")
+	t.Setenv("KLAUS_EMBEDDING_MODEL", "text-embedding-3-small")
+	s := New("http://kagent:9090", "myagent")
+	_, isKagent := s.(*KagentStore)
+	require.True(t, isKagent, "expected KagentStore when fully configured")
+}

--- a/pkg/server/a2aroutes_test.go
+++ b/pkg/server/a2aroutes_test.go
@@ -20,6 +20,8 @@ func newTestExecutor() *a2a.Executor {
 		&mockPrompter{status: claude.StatusInfo{Status: claude.ProcessStatusIdle}},
 		a2a.ModeChat,
 		nil,
+		nil,
+		0,
 	)
 }
 

--- a/pkg/server/a2aroutes_test.go
+++ b/pkg/server/a2aroutes_test.go
@@ -19,6 +19,7 @@ func newTestExecutor() *a2a.Executor {
 	return a2a.New(
 		&mockPrompter{status: claude.StatusInfo{Status: claude.ProcessStatusIdle}},
 		a2a.ModeChat,
+		nil,
 	)
 }
 


### PR DESCRIPTION
## What changed

**kagent push** (existing): on each turn, push user+agent events and task metadata to the kagent-controller REST API (`POST /api/sessions/events`, `POST /api/tasks`).

**Cross-session memory** (new): per-user recall across conversations. When the kagent UI starts a new conversation it mints a fresh `contextId`, cold-starting the pod with no recollection of prior sessions. This adds per-user memory keyed on the caller's JWT `sub`:

- **Retrieval (turn start, agent mode):** top-K chunks from previous sessions are retrieved via `POST /api/memories/search` and injected via `--append-system-prompt` on the `--resume` invocation. Turns with no identity are silently memory-less.
- **Recording (async, after turn):** both sides of each turn are stored via `POST /api/memories/sessions` alongside the existing kagent push.
- **Embedding:** stdlib-only `net/http` OpenAI-compatible client; truncates to 768 dims and L2-normalises (matches kagent's pgvector contract). Configure `KLAUS_EMBEDDING_MODEL` to match the model kagent uses so vectors share the same space.

**New env vars:**

| Env | Default | Notes |
|---|---|---|
| `MEMORY_ENABLED` | `false` | Set to `true` to activate |
| `MEMORY_TOP_K` | `5` | Max chunks injected per turn |
| `Klaus_EMBEDDING_ENDPOINT` | `https://api.openai.com/v1` | OpenAI-compatible base URL |
| `KLAUS_EMBEDDING_MODEL` | _(required)_ | e.g. `text-embedding-3-small` |
| `KLAUS_EMBEDDING_API_KEY` | _(optional)_ | Omit for unauthenticated vLLM |

Reuses `KAGENT_API_ENDPOINT` + `KAGENT_AGENT_REF` as the memory backend endpoint and scoping key — no new service required.

Chat mode gets memory at cold-start only (system prompt is set once at process launch). The target path — fresh contextId from kagent UI — runs in agent mode and gets per-turn injection.