### PR TITLE
feat: default to Claude Fable 5 and bump claude-code to 2.1.170

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN if [ "$VARIANT" = "alpine" ]; then \
 
 # Install Claude Code CLI globally.
 # renovate: datasource=npm depName=@anthropic-ai/claude-code
-ARG CLAUDE_CODE_VER=2.1.168
+ARG CLAUDE_CODE_VER=2.1.170
 RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VER} && \
     npm cache clean --force
 

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -45,7 +45,7 @@ RUN if [ "$VARIANT" = "alpine" ]; then \
 
 # Install Claude Code CLI globally.
 # renovate: datasource=npm depName=@anthropic-ai/claude-code
-ARG CLAUDE_CODE_VER=2.1.168
+ARG CLAUDE_CODE_VER=2.1.170
 RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VER} && \
     npm cache clean --force
 

--- a/helm/klaus/values.schema.json
+++ b/helm/klaus/values.schema.json
@@ -26,7 +26,7 @@
       "properties": {
         "model": {
           "type": "string",
-          "description": "Claude model to use (e.g. claude-sonnet-4-20250514, sonnet, opus)"
+          "description": "Claude model to use (e.g. claude-fable-5, fable, sonnet, opus); empty uses the klaus default (fable)"
         },
         "maxTurns": {
           "type": "integer",

--- a/helm/klaus/values.yaml
+++ b/helm/klaus/values.yaml
@@ -19,8 +19,8 @@ toolchainImage: ""
 
 # Claude Code agent configuration.
 claude:
-  # model is the Claude model to use (e.g. "claude-sonnet-4-20250514", "sonnet", "opus").
-  # Empty string uses the Claude CLI default.
+  # model is the Claude model to use (e.g. "claude-fable-5", "fable", "sonnet", "opus").
+  # Empty string uses the klaus default ("fable", the latest Claude Fable model).
   model: ""
   # maxTurns limits the number of agentic turns per prompt.
   # 0 means no limit.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -29,6 +29,11 @@ const (
 
 	// maxConfigFileSize is the maximum allowed size for a config file (1 MiB).
 	maxConfigFileSize = 1 << 20
+
+	// DefaultModel is the model used when neither the config file nor the
+	// CLAUDE_MODEL env var selects one. The "fable" alias tracks the latest
+	// Claude Fable model (requires Claude Code >= 2.1.170).
+	DefaultModel = "fable"
 )
 
 // Config is the top-level configuration for the klaus server.
@@ -46,7 +51,8 @@ type Config struct {
 // ClaudeConfig holds settings that are forwarded to the Claude Code CLI.
 // These map directly to claude CLI flags and are not consumed by klaus itself.
 type ClaudeConfig struct {
-	// Model selects the Claude model (e.g. "claude-sonnet-4-20250514", "sonnet", "opus").
+	// Model selects the Claude model (e.g. "claude-fable-5", "fable", "sonnet", "opus").
+	// Defaults to DefaultModel when left empty.
 	Model string `yaml:"model"`
 	// SystemPrompt overrides the default system prompt entirely.
 	SystemPrompt string `yaml:"systemPrompt"`
@@ -191,6 +197,11 @@ func Load(path string) (Config, error) {
 
 	// Apply environment variable overrides.
 	applyEnvOverrides(&cfg)
+
+	// Apply global defaults for settings left empty by both YAML and env.
+	if cfg.Claude.Model == "" {
+		cfg.Claude.Model = DefaultModel
+	}
 
 	return cfg, nil
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -150,6 +150,17 @@ func TestLoad_FileNotFound_EnvOnly(t *testing.T) {
 	assertEqual(t, "server.ownerSubject", "admin@example.com", cfg.Server.OwnerSubject)
 }
 
+func TestLoad_DefaultModel(t *testing.T) {
+	t.Setenv("CLAUDE_MODEL", "")
+
+	cfg, err := Load("/nonexistent/config.yaml")
+	if err != nil {
+		t.Fatalf("Load with missing file: %v", err)
+	}
+
+	assertEqual(t, "claude.model", DefaultModel, cfg.Claude.Model)
+}
+
 func TestLoad_EnvOverridesYAML(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.yaml")


### PR DESCRIPTION
## Summary

- Bump the pinned Claude Code CLI from 2.1.168 to 2.1.170 in both Dockerfiles -- Fable 5 requires >= 2.1.170.
- Introduce a global default model: when neither the config file nor `CLAUDE_MODEL` selects a model, klaus now defaults to the `fable` alias (latest Claude Fable model) instead of falling back to the Claude CLI account default.
- Update helm values/schema docs to reflect the new default; explicit `claude.model` settings keep overriding it.

## Test plan

- [x] `go build ./...` and full `go test ./...` pass, including a new `TestLoad_DefaultModel`.
- [x] Built the image locally and ran a klausctl instance with no model configured: assistant message metadata reports `claude-fable-5`.

Made with [Cursor](https://cursor.com)