### PR TITLE
chore: drop auto-release.yaml from lint-yaml target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 
+- Drop the removed `.github/workflows/auto-release.yaml` from the `lint-yaml` make target.
 
 
 - Bump `giantswarm/architect` orb to `8.2.2` and re-enable cosign keyless chart signing (`sign: false` removed from every `push-to-app-catalog*` invocation). v8.2.2 ships [architect-orb#772](https://github.com/giantswarm/architect-orb/pull/772) which upgrades the `app-build-suite` executor image from `1.8.0-circleci` to `1.8.1-circleci` -- the new image includes the `cosign` binary that v8.2.0's chart signing defaults require. Closes [architect-orb#769](https://github.com/giantswarm/architect-orb/issues/769).

--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -35,7 +35,7 @@ generate-dockerfile-debian: ## Regenerate Dockerfile.debian from Dockerfile (onl
 .PHONY: lint-yaml
 lint-yaml: ## Run YAML linter
 	@echo "Running YAML linter..."
-	@yamllint .github/workflows/auto-release.yaml .github/workflows/ci.yaml .goreleaser.yaml .goreleaser.ci.yaml
+	@yamllint .github/workflows/ci.yaml .goreleaser.yaml .goreleaser.ci.yaml
 
 .PHONY: check
 check: lint-yaml test-vet ## Run YAML linter and Go tests


### PR DESCRIPTION
## Summary

The `.github/workflows/auto-release.yaml` workflow file has been removed at the platform level, so the `lint-yaml` make target currently fails (`yamllint` errors on the missing file). This drops the reference so `make lint-yaml` works again.

Note: this repo still has a `test-auto-release` make target that calls `act` against the same workflow. That target is out of scope here — opening a separate change for it if needed.

## Test plan

- [ ] `make lint-yaml` succeeds locally
- [ ] `make check` succeeds locally