### PR TITLE
fix(build): use CI-built binary in container image instead of rebuilding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,30 +3,12 @@
 # Declared before the first FROM so it is available to all FROM instructions.
 ARG VARIANT=alpine
 
-# Stage 1: Build the Go binary (runs on the build host, cross-compiles for target).
-FROM --platform=$BUILDPLATFORM golang:1.26.4 AS builder
+# The Go binary is built by CircleCI (architect/go-build) and attached to the
+# build context as klaus-<os>-<arch>; this image only assembles the runtime.
+# For a local build, produce the binary first (or use `make docker-build`):
+#   CGO_ENABLED=0 go build -o klaus-linux-amd64 .
 
-WORKDIR /app
-COPY go.mod go.sum ./
-RUN go mod download
-
-COPY . .
-ARG VERSION=
-ARG COMMIT=
-ARG DATE=
-ARG TARGETOS
-ARG TARGETARCH
-RUN VERSION=${VERSION:-$(git describe --tags --always --dirty 2>/dev/null || echo "dev")} && \
-    COMMIT=${COMMIT:-$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")} && \
-    DATE=${DATE:-$(date -u +%Y-%m-%dT%H:%M:%SZ)} && \
-    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -trimpath \
-    -ldflags "-w -extldflags '-static' \
-    -X 'main.version=${VERSION}' \
-    -X 'main.commit=${COMMIT}' \
-    -X 'main.date=${DATE}'" \
-    -o klaus .
-
-# Stage 2: Minimal runtime with Node.js and Claude CLI.
+# Minimal runtime with Node.js and Claude CLI.
 FROM node:24-${VARIANT}
 ARG VARIANT
 
@@ -57,8 +39,10 @@ RUN if [ "$VARIANT" = "alpine" ]; then \
 # Create workspace directory.
 RUN mkdir -p /workspace && chown klaus:klaus /workspace
 
-# Copy the Go binary from the builder stage.
-COPY --from=builder /app/klaus /usr/local/bin/klaus
+# Copy the prebuilt Go binary for the target platform.
+ARG TARGETOS
+ARG TARGETARCH
+COPY klaus-${TARGETOS}-${TARGETARCH} /usr/local/bin/klaus
 
 LABEL io.giantswarm.klaus.type=toolchain \
       io.giantswarm.klaus.name=klaus

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -7,30 +7,12 @@
 # Declared before the first FROM so it is available to all FROM instructions.
 ARG VARIANT=slim
 
-# Stage 1: Build the Go binary (runs on the build host, cross-compiles for target).
-FROM --platform=$BUILDPLATFORM golang:1.26.4 AS builder
+# The Go binary is built by CircleCI (architect/go-build) and attached to the
+# build context as klaus-<os>-<arch>; this image only assembles the runtime.
+# For a local build, produce the binary first (or use `make docker-build`):
+#   CGO_ENABLED=0 go build -o klaus-linux-amd64 .
 
-WORKDIR /app
-COPY go.mod go.sum ./
-RUN go mod download
-
-COPY . .
-ARG VERSION=
-ARG COMMIT=
-ARG DATE=
-ARG TARGETOS
-ARG TARGETARCH
-RUN VERSION=${VERSION:-$(git describe --tags --always --dirty 2>/dev/null || echo "dev")} && \
-    COMMIT=${COMMIT:-$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")} && \
-    DATE=${DATE:-$(date -u +%Y-%m-%dT%H:%M:%SZ)} && \
-    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -trimpath \
-    -ldflags "-w -extldflags '-static' \
-    -X 'main.version=${VERSION}' \
-    -X 'main.commit=${COMMIT}' \
-    -X 'main.date=${DATE}'" \
-    -o klaus .
-
-# Stage 2: Minimal runtime with Node.js and Claude CLI.
+# Minimal runtime with Node.js and Claude CLI.
 FROM node:24-${VARIANT}
 ARG VARIANT
 
@@ -61,8 +43,10 @@ RUN if [ "$VARIANT" = "alpine" ]; then \
 # Create workspace directory.
 RUN mkdir -p /workspace && chown klaus:klaus /workspace
 
-# Copy the Go binary from the builder stage.
-COPY --from=builder /app/klaus /usr/local/bin/klaus
+# Copy the prebuilt Go binary for the target platform.
+ARG TARGETOS
+ARG TARGETARCH
+COPY klaus-${TARGETOS}-${TARGETARCH} /usr/local/bin/klaus
 
 LABEL io.giantswarm.klaus.type=toolchain \
       io.giantswarm.klaus.name=klaus

--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -45,7 +45,7 @@ generate-dockerfile-debian: ## Regenerate Dockerfile.debian from Dockerfile (onl
 .PHONY: lint-yaml
 lint-yaml: ## Run YAML linter
 	@echo "Running YAML linter..."
-	@yamllint .github/workflows/auto-release.yaml .github/workflows/ci.yaml .goreleaser.yaml .goreleaser.ci.yaml
+	@yamllint .github/workflows/ci.yaml .goreleaser.yaml .goreleaser.ci.yaml
 
 .PHONY: check
 check: lint-yaml test-vet ## Run YAML linter and Go tests

--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -14,15 +14,25 @@ release-local: ## Create a release locally
 
 ##@ Docker
 
-.PHONY: docker-build docker-build-alpine docker-build-debian generate-dockerfile-debian
+.PHONY: docker-build docker-build-alpine docker-build-debian docker-binary generate-dockerfile-debian
 
 docker-build: docker-build-alpine docker-build-debian ## Build both Alpine and Debian Docker images
 
-docker-build-alpine: ## Build Alpine Docker image (default)
+# The Dockerfile copies a prebuilt klaus-<os>-<arch> binary (built by CI in
+# the architect/go-build job); build it locally before the image build.
+docker-binary:
+	@echo "Building klaus-linux-$$(go env GOARCH)..."
+	@CGO_ENABLED=0 GOOS=linux go build -trimpath \
+		-ldflags "-w -extldflags '-static' \
+		-X 'github.com/giantswarm/klaus/pkg/project.gitSHA=$$(git rev-parse --short HEAD 2>/dev/null || echo unknown)' \
+		-X 'github.com/giantswarm/klaus/pkg/project.buildTimestamp=$$(date -u +%Y-%m-%dT%H:%M:%SZ)'" \
+		-o klaus-linux-$$(go env GOARCH) .
+
+docker-build-alpine: docker-binary ## Build Alpine Docker image (default)
 	@echo "Building Alpine image..."
 	@docker build -t klaus:alpine .
 
-docker-build-debian: ## Build Debian Docker image
+docker-build-debian: docker-binary ## Build Debian Docker image
 	@echo "Building Debian image..."
 	@docker build -f Dockerfile.debian -t klaus:debian .
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -27,8 +27,8 @@ When run without subcommands, it starts the server (equivalent to 'klaus serve')
 
 // SetBuildInfo propagates build-time metadata to the root command and pkg/project.
 func SetBuildInfo(version, commit, date string) {
-	rootCmd.Version = version
 	project.SetBuildInfo(version, commit, date)
+	rootCmd.Version = project.Version()
 }
 
 // Execute runs the root command and exits on error.

--- a/main.go
+++ b/main.go
@@ -4,11 +4,13 @@ import (
 	"github.com/giantswarm/klaus/cmd"
 )
 
-// Build-time variables set via ldflags (goreleaser & Dockerfile).
+// Build-time variables set via ldflags by goreleaser. Container builds inject
+// build metadata directly into pkg/project via architect-orb's go-build job,
+// so the defaults here stay empty to avoid clobbering those values.
 var (
-	version = "dev"
-	commit  = "unknown"
-	date    = "unknown"
+	version string
+	commit  string
+	date    string
 )
 
 func main() {

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -1,5 +1,12 @@
 package project
 
+// Populated at link time via `-X` ldflags. Two injection paths:
+//
+//   - goreleaser (release archives) sets main.version/commit/date, which are
+//     propagated here through cmd.SetBuildInfo.
+//   - architect-orb's go-build job (container images) sets gitSHA and
+//     buildTimestamp directly; version stays at its default because no tag
+//     is plumbed through.
 var (
 	buildTimestamp string
 	gitSHA         string
@@ -38,7 +45,14 @@ func SetBuildInfo(v, commit, date string) {
 	}
 }
 
-// Version returns the application version set at compile time.
+// Version returns the best human-readable build identifier available: the
+// release tag if one was injected, otherwise the commit SHA, otherwise "dev".
 func Version() string {
-	return version
+	if version != "dev" && version != "" {
+		return version
+	}
+	if gitSHA != "" {
+		return gitSHA
+	}
+	return "dev"
 }


### PR DESCRIPTION
## Summary

- The Dockerfile (and generated `Dockerfile.debian`) rebuilt the Go binary in a `golang` builder stage even though CircleCI's `architect/go-build` job already builds, tests, and signs `klaus-<os>-<arch>` binaries and attaches them to the workspace. The image now copies the prebuilt binary for the target platform — same pattern as muster. Every image variant build (alpine/debian, registries/toolchains) stops paying a full Go compile per platform, and the binary that ships is the one CI built.
- Build metadata: the orb injects `pkg/project.gitSHA` / `pkg/project.buildTimestamp` via ldflags; `main` ldflag defaults are now empty so they no longer clobber those values, and `project.Version()` falls back to the commit SHA when no release tag was injected (goreleaser archives still inject `main.version`).
- `make docker-build` compiles the binary locally before the image build.

## Test plan

- [x] `go build ./...` and `go vet ./...` pass
- [x] Local image builds for both variants with a prebuilt `klaus-linux-amd64` succeed; `docker run --rm klaus:alpine version` works
- [ ] Branch CI: all push-to-registries/toolchains jobs green

Made with [Cursor](https://cursor.com)