### PR TITLE
fix: fail loudly on errored runs; stop pinning the model to gated "fable"

### DIFF
--- a/helm/klaus/values.schema.json
+++ b/helm/klaus/values.schema.json
@@ -26,7 +26,7 @@
       "properties": {
         "model": {
           "type": "string",
-          "description": "Claude model to use (e.g. claude-fable-5, fable, sonnet, opus); empty uses the klaus default (fable)"
+          "description": "Claude model to use (e.g. sonnet, opus, claude-sonnet-4-20250514); empty passes no --model flag so the Claude CLI's own default is used (klaus does not pin a model)"
         },
         "maxTurns": {
           "type": "integer",

--- a/helm/klaus/values.yaml
+++ b/helm/klaus/values.yaml
@@ -19,8 +19,9 @@ toolchainImage: ""
 
 # Claude Code agent configuration.
 claude:
-  # model is the Claude model to use (e.g. "claude-fable-5", "fable", "sonnet", "opus").
-  # Empty string uses the klaus default ("fable", the latest Claude Fable model).
+  # model is the Claude model to use (e.g. "sonnet", "opus", "claude-sonnet-4-20250514").
+  # Empty string passes no --model flag, so the Claude CLI's own (auto-upgrading)
+  # default is used; klaus does not pin a model.
   model: ""
   # maxTurns limits the number of agentic turns per prompt.
   # 0 means no limit.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -29,11 +29,6 @@ const (
 
 	// maxConfigFileSize is the maximum allowed size for a config file (1 MiB).
 	maxConfigFileSize = 1 << 20
-
-	// DefaultModel is the model used when neither the config file nor the
-	// CLAUDE_MODEL env var selects one. The "fable" alias tracks the latest
-	// Claude Fable model (requires Claude Code >= 2.1.170).
-	DefaultModel = "fable"
 )
 
 // Config is the top-level configuration for the klaus server.
@@ -51,8 +46,9 @@ type Config struct {
 // ClaudeConfig holds settings that are forwarded to the Claude Code CLI.
 // These map directly to claude CLI flags and are not consumed by klaus itself.
 type ClaudeConfig struct {
-	// Model selects the Claude model (e.g. "claude-fable-5", "fable", "sonnet", "opus").
-	// Defaults to DefaultModel when left empty.
+	// Model selects the Claude model (e.g. "claude-sonnet-4-20250514", "sonnet", "opus").
+	// Left empty by default so the Claude CLI's own (auto-upgrading) default is
+	// used; klaus does not pin a model.
 	Model string `yaml:"model"`
 	// SystemPrompt overrides the default system prompt entirely.
 	SystemPrompt string `yaml:"systemPrompt"`
@@ -198,10 +194,11 @@ func Load(path string) (Config, error) {
 	// Apply environment variable overrides.
 	applyEnvOverrides(&cfg)
 
-	// Apply global defaults for settings left empty by both YAML and env.
-	if cfg.Claude.Model == "" {
-		cfg.Claude.Model = DefaultModel
-	}
+	// Note: Claude.Model is intentionally left empty when unset. klaus must not
+	// pin a default model: an empty model means no --model flag is passed to the
+	// Claude CLI, so the model tracks the CLI's own (auto-upgrading) default.
+	// Hardcoding a model here (see the reverted "fable" default) silently breaks
+	// every run if that model is later retired or gated.
 
 	return cfg, nil
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -158,7 +158,11 @@ func TestLoad_DefaultModel(t *testing.T) {
 		t.Fatalf("Load with missing file: %v", err)
 	}
 
-	assertEqual(t, "claude.model", DefaultModel, cfg.Claude.Model)
+	// klaus must not pin a model: with nothing configured the model stays
+	// empty so no --model flag is passed and the Claude CLI's own default is
+	// used. Regression guard for the "fable" hardcode that silently broke
+	// every run once the Fable family was gated.
+	assertEqual(t, "claude.model", "", cfg.Claude.Model)
 }
 
 func TestLoad_EnvOverridesYAML(t *testing.T) {

--- a/pkg/server/chat.go
+++ b/pkg/server/chat.go
@@ -73,6 +73,13 @@ type chatCompletionUse struct {
 // when a completion terminates normally.
 const finishReasonStop = "stop"
 
+// finishReasonError is emitted when the agent run terminated in an error
+// state (e.g. the underlying claude subprocess exited non-zero, or a result
+// message reported is_error). Without this, a failed run is indistinguishable
+// from a successful one on the wire and callers report success for a run that
+// produced nothing — see the memory-keeper silent-failure incident.
+const finishReasonError = "error"
+
 // handleChatCompletions returns an http.HandlerFunc that accepts an
 // OpenAI-compatible chat completion request and streams the response as SSE
 // (or returns a complete response for non-streaming requests).
@@ -155,6 +162,7 @@ func streamResponse(w http.ResponseWriter, r *http.Request, process claudepkg.Pr
 	sentRole := false
 	var usage *chatCompletionUse
 	toolIndex := 0
+	resultErrored := false
 
 	for {
 		select {
@@ -165,7 +173,7 @@ func streamResponse(w http.ResponseWriter, r *http.Request, process claudepkg.Pr
 			return
 		case msg, ok := <-ch:
 			if !ok {
-				writeDoneChunk(w, flusher, id, model, usage)
+				writeDoneChunk(w, flusher, id, model, runFinishReason(process, resultErrored), usage)
 				return
 			}
 
@@ -174,6 +182,9 @@ func streamResponse(w http.ResponseWriter, r *http.Request, process claudepkg.Pr
 				// Capture usage from result messages even though we don't emit a delta.
 				if msg.Type == claudepkg.MessageTypeResult {
 					usage = collectUsage(msg, usage)
+					if msg.IsError {
+						resultErrored = true
+					}
 				}
 				continue
 			}
@@ -203,15 +214,28 @@ func streamResponse(w http.ResponseWriter, r *http.Request, process claudepkg.Pr
 	}
 }
 
-// writeDoneChunk sends the final SSE chunk with finish_reason "stop" and the [DONE] sentinel.
-func writeDoneChunk(w http.ResponseWriter, flusher http.Flusher, id, model string, usage *chatCompletionUse) {
-	stop := finishReasonStop
+// runFinishReason determines the terminal finish_reason for a completed run.
+// It reports "error" when a result message flagged is_error, or when the
+// process ended in the error state. By the time the message channel closes,
+// the process has already run cmd.Wait() and updated its status (the channel
+// is closed after the status transition in pkg/claude), so Status() is
+// authoritative here.
+func runFinishReason(process claudepkg.Prompter, resultErrored bool) string {
+	if resultErrored || process.Status().Status == claudepkg.ProcessStatusError {
+		return finishReasonError
+	}
+	return finishReasonStop
+}
+
+// writeDoneChunk sends the final SSE chunk carrying the terminal finish_reason
+// and the [DONE] sentinel.
+func writeDoneChunk(w http.ResponseWriter, flusher http.Flusher, id, model, finishReason string, usage *chatCompletionUse) {
 	final := chatCompletionResponse{
 		ID:      id,
 		Object:  chatCompletionChunkObject,
 		Created: time.Now().Unix(),
 		Model:   model,
-		Choices: []chatChoice{{Index: 0, Delta: &chatMessage{}, FinishReason: &stop}},
+		Choices: []chatChoice{{Index: 0, Delta: &chatMessage{}, FinishReason: &finishReason}},
 		Usage:   usage,
 	}
 	data, err := json.Marshal(final)
@@ -247,7 +271,13 @@ func collectResponse(w http.ResponseWriter, ch <-chan claudepkg.StreamMessage, m
 
 	resultText := claudepkg.CollectResultText(msgs)
 
-	stop := finishReasonStop
+	finishReason := finishReasonStop
+	for _, m := range msgs {
+		if m.Type == claudepkg.MessageTypeResult && m.IsError {
+			finishReason = finishReasonError
+			break
+		}
+	}
 	resp := chatCompletionResponse{
 		ID:      fmt.Sprintf("chatcmpl-%d", time.Now().UnixNano()),
 		Object:  "chat.completion",
@@ -256,7 +286,7 @@ func collectResponse(w http.ResponseWriter, ch <-chan claudepkg.StreamMessage, m
 		Choices: []chatChoice{{
 			Index:        0,
 			Message:      &chatMessage{Role: roleAssistant, Content: resultText},
-			FinishReason: &stop,
+			FinishReason: &finishReason,
 		}},
 	}
 

--- a/pkg/server/chat_test.go
+++ b/pkg/server/chat_test.go
@@ -149,6 +149,41 @@ func TestHandleChatCompletions_Streaming(t *testing.T) {
 	}
 }
 
+func TestHandleChatCompletions_StreamingFinishReasonError(t *testing.T) {
+	// A run that ends in error (e.g. the model was unavailable and the
+	// subprocess exited non-zero) must terminate the stream with
+	// finish_reason "error" so blocking callers do not report success for a
+	// run that produced nothing. Regression guard for the memory-keeper
+	// silent-failure incident.
+	prompter := &chatTestPrompter{
+		status: claude.StatusInfo{Status: claude.ProcessStatusError},
+		runFn: func(_ context.Context, _ string, _ *claude.RunOptions) (<-chan claude.StreamMessage, error) {
+			ch := make(chan claude.StreamMessage, 2)
+			ch <- claude.StreamMessage{Type: claude.MessageTypeResult, Result: "model unavailable", IsError: true}
+			close(ch)
+			return ch, nil
+		},
+	}
+
+	body := `{"messages":[{"role":"user","content":"hi"}],"stream":true}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+	w := httptest.NewRecorder()
+
+	handleChatCompletions(prompter)(w, req)
+
+	chunks, gotDone := parseSSEChunks(t, w)
+	if !gotDone {
+		t.Error("expected [DONE] sentinel")
+	}
+	if len(chunks) == 0 {
+		t.Fatal("expected at least the final chunk")
+	}
+	last := chunks[len(chunks)-1]
+	if last.Choices[0].FinishReason == nil || *last.Choices[0].FinishReason != "error" {
+		t.Errorf("expected final finish_reason 'error', got %v", last.Choices[0].FinishReason)
+	}
+}
+
 func TestHandleChatCompletions_StreamingSkipsAssistantMessages(t *testing.T) {
 	// With --include-partial-messages, assistant messages are redundant
 	// (content already delivered via stream_event deltas) and must be skipped.


### PR DESCRIPTION
## Summary

The `memory-keeper` stop hook (and any blocking caller) silently stopped doing useful work for ~6 days after #317 set the default model to `fable`: the whole Claude Fable family got gated, every default run failed, yet runs reported success. This fixes the two root causes in klaus.

- **Stop pinning the model.** #317 introduced `DefaultModel = "fable"` and forced it whenever no model was configured. The `fable` alias was meant to auto-track the latest Fable model, but the family is now gated, so every default run hit "Claude Fable 5 is currently unavailable" and exited non-zero. `Claude.Model` is now left empty when unset, so **no `--model` flag is passed and the Claude CLI's own (auto-upgrading) default is used** — klaus does not pin a model.
- **Fail loudly on errored runs.** The chat-completions stream always emitted `finish_reason: "stop"`, even when the run ended in error (result `is_error`, or process status `error`). A failed run was indistinguishable from success on the wire. The stream now emits `finish_reason: "error"` for failed runs (streaming and non-streaming paths).

Together with giantswarm/klausctl#281 (which makes blocking `run`/`prompt` and the `klaus_run` MCP tool surface that error as a non-zero exit / real status), a future model outage fails visibly instead of silently.

## Changes

- `pkg/config/config.go`: remove the hardcoded `DefaultModel = "fable"` and the forced default; leave model empty so the CLI default applies.
- `pkg/server/chat.go`: emit `finish_reason: "error"` when the run terminated in error.
- helm `values.yaml` / `values.schema.json`: drop stale "default fable" comments.
- Regression tests: error `finish_reason` (streaming) and the no-pin default.

## Test plan

- [x] `go build ./...`
- [x] `go test ./pkg/config/ ./pkg/server/ ./pkg/claude/`
- [x] new tests: `TestHandleChatCompletions_StreamingFinishReasonError`, updated `TestLoad_DefaultModel`
- [ ] CI green

Made with [Cursor](https://cursor.com)
