### PR TITLE
fix(helm): restore free-form map values rejected by generated schema

### DIFF
--- a/helm/klaus/values.schema.json
+++ b/helm/klaus/values.schema.json
@@ -5,7 +5,7 @@
     "properties": {
         "affinity": {
             "type": "object",
-            "additionalProperties": false
+            "additionalProperties": true
         },
         "anthropicApiKey": {
             "type": "object",
@@ -48,12 +48,18 @@
                 "agentFiles": {
                     "type": "object",
                     "description": "Inline subagent files (markdown format) -- These are mounted as .claude/agents/<name>.md files. Claude Code discovers them and makes them available for delegation via the Task tool, and for selection as the main agent via activeAgent or the MCP agent parameter. Subagents defined here have lower priority than those in `agents` (JSON). See https://code.claude.com/docs/en/sub-agents Example: agentFiles: researcher: content: | name: researcher description: Research agent that gathers information tools: Read, Grep, Glob You are a research agent...",
-                    "additionalProperties": false
+                    "additionalProperties": {
+                        "type": "object",
+                        "additionalProperties": true
+                    }
                 },
                 "agents": {
                     "type": "object",
                     "description": "Subagents (JSON format, highest priority) -- Subagents are specialized AI assistants that the main Claude Code agent can delegate work to via the built-in \"Task\" tool. Each runs in its own context window with its own prompt, tools, model, and permissions. These have the highest priority and override agent files with the same name. See https://code.claude.com/docs/en/sub-agents Example: agents: reviewer: description: \"Reviews code changes. Use proactively after edits.\" prompt: \"You are a senior code reviewer...\" tools: [\"Read\", \"Grep\", \"Glob\", \"Bash\"] model: \"sonnet\" deployer: description: \"Handles deployments\" prompt: \"You are a deployment specialist...\"",
-                    "additionalProperties": false
+                    "additionalProperties": {
+                        "type": "object",
+                        "additionalProperties": true
+                    }
                 },
                 "allowedTools": {
                     "type": "array"
@@ -72,12 +78,16 @@
                 },
                 "hookScripts": {
                     "type": "object",
-                    "additionalProperties": false
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 },
                 "hooks": {
                     "type": "object",
                     "description": "Hooks -- hooks defines Claude Code lifecycle hooks, rendered to settings.json. Mutually exclusive with settingsFile. Example: hooks: PreToolUse: - matcher: \"Bash\" hooks: - type: command command: /etc/klaus/hooks/block-dangerous.sh",
-                    "additionalProperties": false
+                    "additionalProperties": {
+                        "type": "array"
+                    }
                 },
                 "includePartialMessages": {
                     "type": "boolean",
@@ -108,7 +118,10 @@
                 },
                 "mcpServers": {
                     "type": "object",
-                    "additionalProperties": false
+                    "additionalProperties": {
+                        "type": "object",
+                        "additionalProperties": true
+                    }
                 },
                 "mcpTimeout": {
                     "type": "integer"
@@ -141,7 +154,10 @@
                 "skills": {
                     "type": "object",
                     "description": "Inline skills -- Supported frontmatter fields: description, disableModelInvocation, userInvocable, allowedTools, model, context, agent, argumentHint. Example: skills: api-conventions: description: \"API design patterns\" content: | When writing API endpoints...",
-                    "additionalProperties": false
+                    "additionalProperties": {
+                        "type": "object",
+                        "additionalProperties": true
+                    }
                 },
                 "strictMcpConfig": {
                     "type": "boolean"
@@ -203,7 +219,9 @@
         },
         "nodeSelector": {
             "type": "object",
-            "additionalProperties": false
+            "additionalProperties": {
+                "type": "string"
+            }
         },
         "owner": {
             "type": "object",
@@ -319,7 +337,9 @@
             "properties": {
                 "annotations": {
                     "type": "object",
-                    "additionalProperties": false
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 },
                 "create": {
                     "type": "boolean"
@@ -399,7 +419,7 @@
                         },
                         "namespaceSelector": {
                             "type": "object",
-                            "additionalProperties": false
+                            "additionalProperties": true
                         },
                         "scrapeTimeout": {
                             "type": "string"
@@ -438,7 +458,7 @@
                 },
                 "gitResources": {
                     "type": "object",
-                    "additionalProperties": false
+                    "additionalProperties": true
                 },
                 "gitSecretName": {
                     "type": "string"

--- a/helm/klaus/values.yaml
+++ b/helm/klaus/values.yaml
@@ -54,7 +54,7 @@ claude:
   #       args: ["-y", "@bytebase/dbhub"]
   #       env:
   #         DB_URL: "${DATABASE_URL}"
-  mcpServers: {}
+  mcpServers: {}  # @schema additionalProperties: {type: object, additionalProperties: true}
   # mcpServerSecrets injects Kubernetes Secret values as container env vars
   # for ${VAR} expansion in MCP server configuration.
   # Example:
@@ -131,7 +131,7 @@ claude:
   #       description: "API design patterns"
   #       content: |
   #         When writing API endpoints...
-  skills: {}
+  skills: {}  # @schema additionalProperties: {type: object, additionalProperties: true}
 
   # -- Inline subagent files (markdown format) --
   # agentFiles defines markdown-format subagent definitions loaded via --add-dir.
@@ -150,7 +150,7 @@ claude:
   #         tools: Read, Grep, Glob
   #         ---
   #         You are a research agent...
-  agentFiles: {}
+  agentFiles: {}  # @schema additionalProperties: {type: object, additionalProperties: true}
 
   # -- Hooks --
   # hooks defines Claude Code lifecycle hooks, rendered to settings.json.
@@ -162,7 +162,7 @@ claude:
   #         hooks:
   #           - type: command
   #             command: /etc/klaus/hooks/block-dangerous.sh
-  hooks: {}
+  hooks: {}  # @schema additionalProperties: {type: array}
   # hookScripts defines hook script contents mounted at /etc/klaus/hooks/ with mode 0755.
   # Example:
   #   hookScripts:
@@ -170,7 +170,7 @@ claude:
   #       #!/bin/bash
   #       INPUT=$(cat)
   #       exit 0
-  hookScripts: {}
+  hookScripts: {}  # @schema additionalProperties: {type: string}
 
   # -- Plugins --
   # plugins references Klaus plugins stored in OCI registries, delivered via
@@ -202,7 +202,7 @@ claude:
   #     deployer:
   #       description: "Handles deployments"
   #       prompt: "You are a deployment specialist..."
-  agents: {}
+  agents: {}  # @schema additionalProperties: {type: object, additionalProperties: true}
   # activeAgent selects which agent runs as the top-level agent for the session
   # (--agent flag). This changes the main agent persona, NOT which subagents
   # are available. The selected agent can still delegate to other subagents.
@@ -275,7 +275,7 @@ workspace:
   #     limits:
   #       cpu: 500m
   #       memory: 512Mi
-  gitResources: {}
+  gitResources: {}  # @schema additionalProperties: true
 
 # OpenTelemetry monitoring configuration.
 # These env vars are inherited by the Claude Code subprocess, enabling its
@@ -328,7 +328,7 @@ telemetry:
     # namespaceSelector restricts which namespaces the ServiceMonitor
     # matches. Leave empty to match only the release namespace (default).
     # Set any=true for cross-namespace matching, or use matchNames.
-    namespaceSelector: {}
+    namespaceSelector: {}  # @schema additionalProperties: true
 
 resources:
   limits:
@@ -356,13 +356,13 @@ securityContext:
 serviceAccount:
   create: true
   name: ""
-  annotations: {}
+  annotations: {}  # @schema additionalProperties: {type: string}
 
-nodeSelector: {}
+nodeSelector: {}  # @schema additionalProperties: {type: string}
 
 tolerations: []
 
-affinity: {}
+affinity: {}  # @schema additionalProperties: true
 
 global:
   podSecurityStandards:


### PR DESCRIPTION
## Problem

Since chart 0.0.298, the regenerated `values.schema.json` ([#432](https://github.com/giantswarm/klaus/pull/432)/[#433](https://github.com/giantswarm/klaus/pull/433)) declares every empty-map value in values.yaml as `type: object, additionalProperties: false` with **no properties** — rejecting all content in these free-form maps while the templates still consume every one of them:

- `claude.skills`, `claude.agents`, `claude.agentFiles`, `claude.hooks`, `claude.hookScripts`, `claude.mcpServers`
- `workspace.gitResources`, `serviceAccount.annotations`, `nodeSelector`, `affinity`, `telemetry.serviceMonitor.namespaceSelector`

Any release setting e.g. a skill or an MCP server fails schema validation on install/upgrade. teemow/spidertron had to work around this with `disableSchemaValidation: true` ([teemow/spidertron#563](https://github.com/teemow/spidertron/pull/563)).

Root cause: `.schema.yaml` sets `noAdditionalProperties: true`, which flattens every un-annotated `{}` in values.yaml.

## Fix

Annotate the free-form maps with `# @schema additionalProperties: ...` in values.yaml (typed value schemas where the value shape is uniform: `{type: string}` for hookScripts/nodeSelector/serviceAccount.annotations, `{type: array}` for hooks, `{type: object, additionalProperties: true}` for the object-valued maps) and regenerate through the pre-commit pipeline (`helm schema` 2.5.0 → $ref fix → `schemalint normalize`). The nested `additionalProperties: true` is needed because `noAdditionalProperties` otherwise recurses into the annotated value schema and flattens it as well.

This keeps the schema generator as the single source (no hand-edited schema) and keeps root-level typo detection intact.

## Verification

- `helm template` passes with all eleven maps populated (skills, agents, agentFiles, hooks, hookScripts, mcpServers, gitResources, annotations, nodeSelector, affinity, namespaceSelector + app-platform injected values)
- `helm template` still rejects an unknown root key
- `helm-docs` produces no README drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)
