### PR TITLE
docs: correct the notify-downstream rationale comment

### DIFF
--- a/.github/workflows/notify-downstream.yaml
+++ b/.github/workflows/notify-downstream.yaml
@@ -9,12 +9,12 @@
 # Auto-release run itself is not subject to that rule.
 #
 # Why the registry wait: the same tag push starts the CircleCI pipeline that
-# builds and pushes the images, which takes ~15-20 minutes. The downstream
+# builds and pushes the images, which takes several minutes. The downstream
 # repos build immediately on dispatch, so dispatching before the manifests
 # exist makes them fail. That ordering guarantee is the only reason dispatch
-# ever lived in CircleCI -- polling gsoci reproduces it without coupling
-# dispatch to the push jobs (notably the Aliyun mirror, which routinely times
-# out on multi-arch images).
+# ever lived in CircleCI -- polling gsoci reproduces it without a cross-system
+# `requires` chain, and gates on the images the downstream repos actually
+# consume rather than on whichever push jobs happen to be listed.
 name: Notify downstream
 
 on:


### PR DESCRIPTION
Comment-only fix to `.github/workflows/notify-downstream.yaml`. No behaviour change.

#440 justified the registry poll partly by saying it avoids "coupling dispatch to the push jobs (notably the Aliyun mirror, which routinely times out on multi-arch images)". That was stale. The push jobs run with `split-china-push: true`, which moved the Aliyun mirror into separate `sync-china-registry-*` jobs -- and the deleted `notify-downstream` job never `require`d those. The dispatch chain had not been coupled to Aliyun since the architect-orb v7.1.0 split-push migration.

The token was the only live blocker, and the registry poll stands on its own merits: it gates on the two images the downstream repos actually consume, rather than on whichever push jobs happen to be listed in a `requires` chain.

Also drops the "~15-20 minutes" estimate -- the first real run took ~4.5 minutes from tag to both manifests present, so the number was misleading. The 40-minute poll ceiling is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)